### PR TITLE
Dex_pallet milestone 1: first iteration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1557,7 +1557,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "fork-tree"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -1565,7 +1565,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1582,7 +1582,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "frame-benchmarking",
  "parity-scale-codec",
@@ -1600,7 +1600,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1615,7 +1615,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata"
 version = "11.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -1626,7 +1626,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "bitmask",
  "frame-metadata",
@@ -1651,7 +1651,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "frame-support-procedural-tools",
  "proc-macro2 1.0.19",
@@ -1662,7 +1662,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -1674,7 +1674,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "proc-macro2 1.0.19",
  "quote 1.0.7",
@@ -1684,7 +1684,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -1700,7 +1700,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -3643,7 +3643,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3659,7 +3659,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3674,7 +3674,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3699,7 +3699,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3713,7 +3713,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3728,7 +3728,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3743,7 +3743,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3757,7 +3757,7 @@ dependencies = [
 [[package]]
 name = "pallet-finality-tracker"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3773,7 +3773,7 @@ dependencies = [
 [[package]]
 name = "pallet-generic-asset"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3785,7 +3785,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3807,7 +3807,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -3823,7 +3823,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3842,7 +3842,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3858,7 +3858,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3872,7 +3872,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3887,7 +3887,7 @@ dependencies = [
 [[package]]
 name = "pallet-nicks"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3901,7 +3901,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3916,7 +3916,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3931,7 +3931,7 @@ dependencies = [
 [[package]]
 name = "pallet-randomness-collective-flip"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3944,7 +3944,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "enumflags2",
  "frame-support",
@@ -3959,7 +3959,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3974,7 +3974,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3994,7 +3994,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4008,7 +4008,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4028,7 +4028,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.19",
@@ -4039,7 +4039,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4053,7 +4053,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4070,7 +4070,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4087,7 +4087,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -4105,7 +4105,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -4118,7 +4118,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4132,7 +4132,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4147,7 +4147,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "enumflags2",
  "frame-support",
@@ -5963,7 +5963,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "bytes 0.5.6",
  "derive_more 0.99.9",
@@ -5990,7 +5990,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
@@ -6014,7 +6014,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -6031,7 +6031,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "impl-trait-for-tuples",
  "sc-chain-spec-derive",
@@ -6047,7 +6047,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.19",
@@ -6058,7 +6058,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "ansi_term 0.12.1",
  "atty",
@@ -6099,7 +6099,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "derive_more 0.99.9",
  "fnv",
@@ -6135,7 +6135,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "blake2-rfc",
  "hash-db",
@@ -6165,7 +6165,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "sc-client-api",
  "sp-blockchain",
@@ -6176,7 +6176,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "derive_more 0.99.9",
  "fork-tree",
@@ -6220,7 +6220,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "derive_more 0.99.9",
  "futures 0.3.5",
@@ -6244,7 +6244,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -6257,7 +6257,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
@@ -6280,7 +6280,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-uncles"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "log 0.4.11",
  "sc-client-api",
@@ -6294,7 +6294,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "derive_more 0.99.9",
  "lazy_static",
@@ -6322,7 +6322,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "derive_more 0.99.9",
  "log 0.4.11",
@@ -6339,7 +6339,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "log 0.4.11",
  "parity-scale-codec",
@@ -6354,7 +6354,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "cranelift-codegen",
  "cranelift-wasm",
@@ -6375,7 +6375,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "assert_matches",
  "derive_more 0.99.9",
@@ -6413,7 +6413,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa-rpc"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "derive_more 0.99.9",
  "finality-grandpa",
@@ -6430,7 +6430,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "ansi_term 0.12.1",
  "futures 0.3.5",
@@ -6448,7 +6448,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "derive_more 0.99.9",
  "hex",
@@ -6464,7 +6464,7 @@ dependencies = [
 [[package]]
 name = "sc-light"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "hash-db",
  "lazy_static",
@@ -6483,7 +6483,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "bitflags",
  "bs58",
@@ -6535,7 +6535,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
@@ -6550,7 +6550,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "bytes 0.5.6",
  "fnv",
@@ -6577,7 +6577,7 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "futures 0.3.5",
  "libp2p",
@@ -6590,7 +6590,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "log 0.4.11",
  "substrate-prometheus-endpoint",
@@ -6599,7 +6599,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "futures 0.3.5",
  "hash-db",
@@ -6631,7 +6631,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "derive_more 0.99.9",
  "futures 0.3.5",
@@ -6655,7 +6655,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-http-server",
@@ -6671,7 +6671,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "derive_more 0.99.9",
  "directories",
@@ -6734,7 +6734,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "log 0.4.11",
  "parity-scale-codec",
@@ -6748,7 +6748,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
@@ -6769,7 +6769,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "erased-serde",
  "log 0.4.11",
@@ -6786,7 +6786,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-graph"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "derive_more 0.99.9",
  "futures 0.3.5",
@@ -6807,7 +6807,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "derive_more 0.99.9",
  "futures 0.3.5",
@@ -7212,7 +7212,7 @@ dependencies = [
 [[package]]
 name = "sp-allocator"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "derive_more 0.99.9",
  "log 0.4.11",
@@ -7224,7 +7224,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "hash-db",
  "parity-scale-codec",
@@ -7239,7 +7239,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "blake2-rfc",
  "proc-macro-crate",
@@ -7251,7 +7251,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -7263,7 +7263,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "integer-sqrt",
  "num-traits 0.2.12",
@@ -7276,7 +7276,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7288,7 +7288,7 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
@@ -7299,7 +7299,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7311,7 +7311,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "derive_more 0.99.9",
  "log 0.4.11",
@@ -7328,7 +7328,7 @@ dependencies = [
 [[package]]
 name = "sp-chain-spec"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "serde",
  "serde_json",
@@ -7337,7 +7337,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "derive_more 0.99.9",
  "futures 0.3.5",
@@ -7363,7 +7363,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7377,7 +7377,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "merlin",
  "parity-scale-codec",
@@ -7396,7 +7396,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -7405,7 +7405,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-vrf"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "parity-scale-codec",
  "schnorrkel",
@@ -7417,7 +7417,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "base58",
  "blake2-rfc",
@@ -7461,7 +7461,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "kvdb",
  "parking_lot 0.10.2",
@@ -7470,7 +7470,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "proc-macro2 1.0.19",
  "quote 1.0.7",
@@ -7480,7 +7480,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -7491,7 +7491,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "finality-grandpa",
  "log 0.4.11",
@@ -7507,7 +7507,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-tracker"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
@@ -7517,7 +7517,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "derive_more 0.99.9",
  "parity-scale-codec",
@@ -7529,7 +7529,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "futures 0.3.5",
  "hash-db",
@@ -7550,7 +7550,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -7561,7 +7561,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -7573,7 +7573,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections-compact"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.19",
@@ -7584,7 +7584,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -7594,7 +7594,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "backtrace",
  "log 0.4.11",
@@ -7603,7 +7603,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "serde",
  "sp-core",
@@ -7612,7 +7612,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -7634,7 +7634,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "parity-scale-codec",
  "primitive-types",
@@ -7649,7 +7649,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -7661,7 +7661,7 @@ dependencies = [
 [[package]]
 name = "sp-serializer"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "serde",
  "serde_json",
@@ -7670,7 +7670,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7683,7 +7683,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -7693,7 +7693,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "hash-db",
  "itertools 0.9.0",
@@ -7714,12 +7714,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 
 [[package]]
 name = "sp-storage"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "impl-serde 0.2.3",
  "ref-cast",
@@ -7731,7 +7731,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -7745,7 +7745,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "log 0.4.11",
  "rental",
@@ -7755,7 +7755,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "derive_more 0.99.9",
  "futures 0.3.5",
@@ -7770,7 +7770,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "hash-db",
  "memory-db",
@@ -7784,7 +7784,7 @@ dependencies = [
 [[package]]
 name = "sp-utils"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "futures 0.3.5",
  "futures-core",
@@ -7796,7 +7796,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "impl-serde 0.2.3",
  "parity-scale-codec",
@@ -7808,7 +7808,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -7927,7 +7927,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "platforms",
 ]
@@ -7935,7 +7935,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures 0.3.5",
@@ -7958,7 +7958,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "async-std",
  "derive_more 0.99.9",
@@ -7972,7 +7972,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-client"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "futures 0.1.29",
  "futures 0.3.5",
@@ -7998,7 +7998,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "cfg-if",
  "frame-executive",
@@ -8038,7 +8038,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime-client"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 dependencies = [
  "futures 0.3.5",
  "parity-scale-codec",
@@ -8065,7 +8065,7 @@ checksum = "d2a965994514ab35d3893e9260245f2947fd1981cdd4fffd2c6e6d1a9ce02e6a"
 [[package]]
 name = "substrate-wasm-builder-runner"
 version = "1.0.6"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
 
 [[package]]
 name = "substrate-wasmtime"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1176,9 +1176,10 @@ version = "2.0.0-rc5"
 dependencies = [
  "frame-support",
  "frame-system",
- "pallet-generic-asset",
+ "pallet-balances",
  "parity-scale-codec",
  "serde",
+ "sp-arithmetic",
  "sp-core",
  "sp-io",
  "sp-runtime",
@@ -3777,7 +3778,6 @@ dependencies = [
  "frame-support",
  "frame-system",
  "parity-scale-codec",
- "serde",
  "sp-runtime",
  "sp-std",
 ]
@@ -4231,7 +4231,7 @@ dependencies = [
  "frame-executive",
  "frame-support",
  "frame-system",
- "pallet-generic-asset",
+ "pallet-balances",
  "pallet-randomness-collective-flip",
  "pallet-sudo",
  "pallet-timestamp",
@@ -8059,13 +8059,13 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder-runner"
 version = "1.0.6"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2a965994514ab35d3893e9260245f2947fd1981cdd4fffd2c6e6d1a9ce02e6a"
 
 [[package]]
 name = "substrate-wasm-builder-runner"
 version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2a965994514ab35d3893e9260245f2947fd1981cdd4fffd2c6e6d1a9ce02e6a"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 
 [[package]]
 name = "substrate-wasmtime"

--- a/node/build.rs
+++ b/node/build.rs
@@ -17,6 +17,6 @@
 use substrate_build_script_utils::{generate_cargo_keys, rerun_if_git_head_changed};
 
 fn main() {
-	generate_cargo_keys();
-	rerun_if_git_head_changed();
+    generate_cargo_keys();
+    rerun_if_git_head_changed();
 }

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -2,7 +2,8 @@
 
 use cumulus_primitives::ParaId;
 use parachain_runtime::{
-	AccountId, GenesisConfig, GenericAssetConfig, DexPalletConfig, DexXCMPConfig, Signature, SudoConfig, SystemConfig, WASM_BINARY, KSMAssetId
+    AccountId, DexPalletConfig, DexXCMPConfig, GenericAssetConfig, GenesisConfig, KSMAssetId,
+    Signature, SudoConfig, SystemConfig, WASM_BINARY,
 };
 use sc_chain_spec::{ChainSpecExtension, ChainSpecGroup};
 use sc_service::ChainType;
@@ -15,26 +16,26 @@ pub type ChainSpec = sc_service::GenericChainSpec<GenesisConfig, Extensions>;
 
 /// Helper function to generate a crypto pair from seed
 pub fn get_from_seed<TPublic: Public>(seed: &str) -> <TPublic::Pair as Pair>::Public {
-	TPublic::Pair::from_string(&format!("//{}", seed), None)
-		.expect("static values are valid; qed")
-		.public()
+    TPublic::Pair::from_string(&format!("//{}", seed), None)
+        .expect("static values are valid; qed")
+        .public()
 }
 
 /// The extensions for the [`ChainSpec`].
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ChainSpecGroup, ChainSpecExtension)]
 #[serde(deny_unknown_fields)]
 pub struct Extensions {
-	/// The relay chain of the Parachain.
-	pub relay_chain: String,
-	/// The id of the Parachain.
-	pub para_id: u32,
+    /// The relay chain of the Parachain.
+    pub relay_chain: String,
+    /// The id of the Parachain.
+    pub para_id: u32,
 }
 
 impl Extensions {
-	/// Try to get the extension from the given `ChainSpec`.
-	pub fn try_get(chain_spec: &Box<dyn sc_service::ChainSpec>) -> Option<&Self> {
-		sc_chain_spec::get_extension(chain_spec.extensions())
-	}
+    /// Try to get the extension from the given `ChainSpec`.
+    pub fn try_get(chain_spec: &Box<dyn sc_service::ChainSpec>) -> Option<&Self> {
+        sc_chain_spec::get_extension(chain_spec.extensions())
+    }
 }
 
 type AccountPublic = <Signature as Verify>::Signer;
@@ -42,96 +43,95 @@ type AccountPublic = <Signature as Verify>::Signer;
 /// Helper function to generate an account ID from seed
 pub fn get_account_id_from_seed<TPublic: Public>(seed: &str) -> AccountId
 where
-	AccountPublic: From<<TPublic::Pair as Pair>::Public>,
+    AccountPublic: From<<TPublic::Pair as Pair>::Public>,
 {
-	AccountPublic::from(get_from_seed::<TPublic>(seed)).into_account()
+    AccountPublic::from(get_from_seed::<TPublic>(seed)).into_account()
 }
 
 pub fn get_chain_spec(id: ParaId) -> ChainSpec {
-	ChainSpec::from_genesis(
-		"Local Testnet",
-		"local_testnet",
-		ChainType::Local,
-		move || {
-			testnet_genesis(
-				get_account_id_from_seed::<sr25519::Public>("Alice"),
-				vec![
-					get_account_id_from_seed::<sr25519::Public>("Alice"),
-					get_account_id_from_seed::<sr25519::Public>("Bob"),
-					get_account_id_from_seed::<sr25519::Public>("Charlie"),
-					get_account_id_from_seed::<sr25519::Public>("Dave"),
-					get_account_id_from_seed::<sr25519::Public>("Eve"),
-					get_account_id_from_seed::<sr25519::Public>("Ferdie"),
-					get_account_id_from_seed::<sr25519::Public>("Alice//stash"),
-					get_account_id_from_seed::<sr25519::Public>("Bob//stash"),
-					get_account_id_from_seed::<sr25519::Public>("Charlie//stash"),
-					get_account_id_from_seed::<sr25519::Public>("Dave//stash"),
-					get_account_id_from_seed::<sr25519::Public>("Eve//stash"),
-					get_account_id_from_seed::<sr25519::Public>("Ferdie//stash"),
-				],
-				id,
-			)
-		},
-		vec![],
-		None,
-		None,
-		None,
-		Extensions {
-			relay_chain: "local_testnet".into(),
-			para_id: id.into(),
-		},
-	)
+    ChainSpec::from_genesis(
+        "Local Testnet",
+        "local_testnet",
+        ChainType::Local,
+        move || {
+            testnet_genesis(
+                get_account_id_from_seed::<sr25519::Public>("Alice"),
+                vec![
+                    get_account_id_from_seed::<sr25519::Public>("Alice"),
+                    get_account_id_from_seed::<sr25519::Public>("Bob"),
+                    get_account_id_from_seed::<sr25519::Public>("Charlie"),
+                    get_account_id_from_seed::<sr25519::Public>("Dave"),
+                    get_account_id_from_seed::<sr25519::Public>("Eve"),
+                    get_account_id_from_seed::<sr25519::Public>("Ferdie"),
+                    get_account_id_from_seed::<sr25519::Public>("Alice//stash"),
+                    get_account_id_from_seed::<sr25519::Public>("Bob//stash"),
+                    get_account_id_from_seed::<sr25519::Public>("Charlie//stash"),
+                    get_account_id_from_seed::<sr25519::Public>("Dave//stash"),
+                    get_account_id_from_seed::<sr25519::Public>("Eve//stash"),
+                    get_account_id_from_seed::<sr25519::Public>("Ferdie//stash"),
+                ],
+                id,
+            )
+        },
+        vec![],
+        None,
+        None,
+        None,
+        Extensions {
+            relay_chain: "local_testnet".into(),
+            para_id: id.into(),
+        },
+    )
 }
 
 pub fn staging_test_net(id: ParaId) -> ChainSpec {
-	ChainSpec::from_genesis(
-		"Staging Testnet",
-		"staging_testnet",
-		ChainType::Live,
-		move || {
-			testnet_genesis(
-				get_account_id_from_seed::<sr25519::Public>("Alice"),
-				vec![get_account_id_from_seed::<sr25519::Public>("Alice")],
-				id,
-			)
-		},
-		Vec::new(),
-		None,
-		None,
-		None,
-		Extensions {
-			relay_chain: "rococo_local_testnet".into(),
-			para_id: id.into(),
-		},
-	)
+    ChainSpec::from_genesis(
+        "Staging Testnet",
+        "staging_testnet",
+        ChainType::Live,
+        move || {
+            testnet_genesis(
+                get_account_id_from_seed::<sr25519::Public>("Alice"),
+                vec![get_account_id_from_seed::<sr25519::Public>("Alice")],
+                id,
+            )
+        },
+        Vec::new(),
+        None,
+        None,
+        None,
+        Extensions {
+            relay_chain: "rococo_local_testnet".into(),
+            para_id: id.into(),
+        },
+    )
 }
 
 fn testnet_genesis(
-	root_key: AccountId,
-	endowed_accounts: Vec<AccountId>,
-	id: ParaId,
+    root_key: AccountId,
+    endowed_accounts: Vec<AccountId>,
+    id: ParaId,
 ) -> GenesisConfig {
-	GenesisConfig {
-		frame_system: Some(SystemConfig {
-			code: WASM_BINARY.to_vec(),
-			changes_trie_config: Default::default(),
-		}),
-		pallet_sudo: Some(SudoConfig {
-			key: root_key.clone(),
-		}),
-		dex_xcmp: Some(DexXCMPConfig {
-			dex_account_id: root_key.clone(),
-		}),
-		dex_pallet: Some(DexPalletConfig {
-			dex_account_id: root_key,
-		}),
-		generic_asset: Some(GenericAssetConfig {
-			assets: vec![],
-			initial_balance: 0,
-			endowed_accounts: endowed_accounts,
-			next_asset_id: KSMAssetId::get() + 1,
-			spending_asset_id: KSMAssetId::get(),
-			staking_asset_id: KSMAssetId::get(),
-		}),
-	}
+    GenesisConfig {
+        frame_system: Some(SystemConfig {
+            code: WASM_BINARY.to_vec(),
+            changes_trie_config: Default::default(),
+        }),
+        pallet_sudo: Some(SudoConfig {
+            key: root_key.clone(),
+        }),
+        dex_xcmp: Some(DexXCMPConfig {
+            dex_account_id: root_key.clone(),
+        }),
+        dex_pallet: Some(DexPalletConfig {
+            dex_account_id: root_key,
+        }),
+        pallet_balances: Some(BalancesConfig {
+            balances: endowed_accounts
+                .iter()
+                .cloned()
+                .map(|k| (k, 1 << 60))
+                .collect(),
+        }),
+    }
 }

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -8,62 +8,62 @@ use structopt::StructOpt;
 /// Sub-commands supported by the collator.
 #[derive(Debug, StructOpt)]
 pub enum Subcommand {
-	#[structopt(flatten)]
-	Base(sc_cli::Subcommand),
+    #[structopt(flatten)]
+    Base(sc_cli::Subcommand),
 
-	/// Export the genesis state of the parachain.
-	#[structopt(name = "export-genesis-state")]
-	ExportGenesisState(ExportGenesisStateCommand),
+    /// Export the genesis state of the parachain.
+    #[structopt(name = "export-genesis-state")]
+    ExportGenesisState(ExportGenesisStateCommand),
 
-	/// Export the genesis wasm of the parachain.
-	#[structopt(name = "export-genesis-wasm")]
-	ExportGenesisWasm(ExportGenesisWasmCommand),
+    /// Export the genesis wasm of the parachain.
+    #[structopt(name = "export-genesis-wasm")]
+    ExportGenesisWasm(ExportGenesisWasmCommand),
 }
 
 /// Command for exporting the genesis state of the parachain
 #[derive(Debug, StructOpt)]
 pub struct ExportGenesisStateCommand {
-	/// Output file name or stdout if unspecified.
-	#[structopt(parse(from_os_str))]
-	pub output: Option<PathBuf>,
+    /// Output file name or stdout if unspecified.
+    #[structopt(parse(from_os_str))]
+    pub output: Option<PathBuf>,
 
-	/// Id of the parachain this state is for.
-	#[structopt(long, default_value = "200")]
-	pub parachain_id: u32,
+    /// Id of the parachain this state is for.
+    #[structopt(long, default_value = "200")]
+    pub parachain_id: u32,
 
-	/// The name of the chain for that the genesis state should be exported.
-	#[structopt(long)]
-	pub chain: Option<String>,
+    /// The name of the chain for that the genesis state should be exported.
+    #[structopt(long)]
+    pub chain: Option<String>,
 }
 
 /// Command for exporting the genesis wasm file.
 #[derive(Debug, StructOpt)]
 pub struct ExportGenesisWasmCommand {
-	/// Output file name or stdout if unspecified.
-	#[structopt(parse(from_os_str))]
-	pub output: Option<PathBuf>,
+    /// Output file name or stdout if unspecified.
+    #[structopt(parse(from_os_str))]
+    pub output: Option<PathBuf>,
 
-	/// The name of the chain for that the genesis wasm file should be exported.
-	#[structopt(long)]
-	pub chain: Option<String>,
+    /// The name of the chain for that the genesis wasm file should be exported.
+    #[structopt(long)]
+    pub chain: Option<String>,
 }
 
 #[derive(Debug, StructOpt)]
 pub struct RunCmd {
-	#[structopt(flatten)]
-	pub base: sc_cli::RunCmd,
+    #[structopt(flatten)]
+    pub base: sc_cli::RunCmd,
 
-	/// Id of the parachain this collator collates for.
-	#[structopt(long)]
-	pub parachain_id: Option<u32>,
+    /// Id of the parachain this collator collates for.
+    #[structopt(long)]
+    pub parachain_id: Option<u32>,
 }
 
 impl std::ops::Deref for RunCmd {
-	type Target = sc_cli::RunCmd;
+    type Target = sc_cli::RunCmd;
 
-	fn deref(&self) -> &Self::Target {
-		&self.base
-	}
+    fn deref(&self) -> &Self::Target {
+        &self.base
+    }
 }
 
 #[derive(Debug, StructOpt)]
@@ -73,40 +73,40 @@ impl std::ops::Deref for RunCmd {
 	structopt::clap::AppSettings::SubcommandsNegateReqs,
 ])]
 pub struct Cli {
-	#[structopt(subcommand)]
-	pub subcommand: Option<Subcommand>,
+    #[structopt(subcommand)]
+    pub subcommand: Option<Subcommand>,
 
-	#[structopt(flatten)]
-	pub run: RunCmd,
+    #[structopt(flatten)]
+    pub run: RunCmd,
 
-	/// Relaychain arguments
-	#[structopt(raw = true)]
-	pub relaychain_args: Vec<String>,
+    /// Relaychain arguments
+    #[structopt(raw = true)]
+    pub relaychain_args: Vec<String>,
 }
 
 #[derive(Debug)]
 pub struct RelayChainCli {
-	/// The actual relay chain cli object.
-	pub base: polkadot_cli::RunCmd,
+    /// The actual relay chain cli object.
+    pub base: polkadot_cli::RunCmd,
 
-	/// Optional chain id that should be passed to the relay chain.
-	pub chain_id: Option<String>,
+    /// Optional chain id that should be passed to the relay chain.
+    pub chain_id: Option<String>,
 
-	/// The base path that should be used by the relay chain.
-	pub base_path: Option<PathBuf>,
+    /// The base path that should be used by the relay chain.
+    pub base_path: Option<PathBuf>,
 }
 
 impl RelayChainCli {
-	/// Create a new instance of `Self`.
-	pub fn new<'a>(
-		base_path: Option<PathBuf>,
-		chain_id: Option<String>,
-		relay_chain_args: impl Iterator<Item = &'a String>,
-	) -> Self {
-		Self {
-			base_path,
-			chain_id,
-			base: polkadot_cli::RunCmd::from_iter(relay_chain_args),
-		}
-	}
+    /// Create a new instance of `Self`.
+    pub fn new<'a>(
+        base_path: Option<PathBuf>,
+        chain_id: Option<String>,
+        relay_chain_args: impl Iterator<Item = &'a String>,
+    ) -> Self {
+        Self {
+            base_path,
+            chain_id,
+            base: polkadot_cli::RunCmd::from_iter(relay_chain_args),
+        }
+    }
 }

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -1,8 +1,8 @@
 // Copyright 2020 Parity Technologies (UK) Ltd.
 
 use crate::{
-	chain_spec,
-	cli::{Cli, RelayChainCli, Subcommand},
+    chain_spec,
+    cli::{Cli, RelayChainCli, Subcommand},
 };
 use codec::Encode;
 use cumulus_primitives::ParaId;
@@ -10,8 +10,8 @@ use log::info;
 use parachain_runtime::Block;
 use polkadot_parachain::primitives::AccountIdConversion;
 use sc_cli::{
-	ChainSpec, CliConfiguration, ImportParams, KeystoreParams, NetworkParams, Result,
-	RuntimeVersion, SharedParams, SubstrateCli, DefaultConfigurationValues,
+    ChainSpec, CliConfiguration, DefaultConfigurationValues, ImportParams, KeystoreParams,
+    NetworkParams, Result, RuntimeVersion, SharedParams, SubstrateCli,
 };
 use sc_service::config::{BasePath, PrometheusConfig};
 use sp_core::hexdisplay::HexDisplay;
@@ -19,350 +19,344 @@ use sp_runtime::traits::{Block as BlockT, Hash as HashT, Header as HeaderT, Zero
 use std::{io::Write, net::SocketAddr, sync::Arc};
 
 impl SubstrateCli for Cli {
-	fn impl_name() -> String {
-		"Parachain Collator Template".into()
-	}
+    fn impl_name() -> String {
+        "Parachain Collator Template".into()
+    }
 
-	fn impl_version() -> String {
-		env!("SUBSTRATE_CLI_IMPL_VERSION").into()
-	}
+    fn impl_version() -> String {
+        env!("SUBSTRATE_CLI_IMPL_VERSION").into()
+    }
 
-	fn description() -> String {
-		format!(
-			"Parachain Collator Template\n\nThe command-line arguments provided first will be \
+    fn description() -> String {
+        format!(
+            "Parachain Collator Template\n\nThe command-line arguments provided first will be \
 		passed to the parachain node, while the arguments provided after -- will be passed \
 		to the relaychain node.\n\n\
 		{} [parachain-args] -- [relaychain-args]",
-			Self::executable_name()
-		)
-	}
+            Self::executable_name()
+        )
+    }
 
-	fn author() -> String {
-		env!("CARGO_PKG_AUTHORS").into()
-	}
+    fn author() -> String {
+        env!("CARGO_PKG_AUTHORS").into()
+    }
 
-	fn support_url() -> String {
-		"https://github.com/paritytech/cumulus/issues/new".into()
-	}
+    fn support_url() -> String {
+        "https://github.com/paritytech/cumulus/issues/new".into()
+    }
 
-	fn copyright_start_year() -> i32 {
-		2017
-	}
+    fn copyright_start_year() -> i32 {
+        2017
+    }
 
-	fn load_spec(&self, id: &str) -> std::result::Result<Box<dyn sc_service::ChainSpec>, String> {
-		match id {
-			"staging" => Ok(Box::new(chain_spec::staging_test_net(
-				self.run.parachain_id.unwrap_or(200).into(),
-			))),
-			"" => Ok(Box::new(chain_spec::get_chain_spec(
-				self.run.parachain_id.unwrap_or(200).into(),
-			))),
-			path => Ok(Box::new(chain_spec::ChainSpec::from_json_file(
-				path.into(),
-			)?)),
-		}
-	}
+    fn load_spec(&self, id: &str) -> std::result::Result<Box<dyn sc_service::ChainSpec>, String> {
+        match id {
+            "staging" => Ok(Box::new(chain_spec::staging_test_net(
+                self.run.parachain_id.unwrap_or(200).into(),
+            ))),
+            "" => Ok(Box::new(chain_spec::get_chain_spec(
+                self.run.parachain_id.unwrap_or(200).into(),
+            ))),
+            path => Ok(Box::new(chain_spec::ChainSpec::from_json_file(
+                path.into(),
+            )?)),
+        }
+    }
 
-	fn native_runtime_version(_: &Box<dyn ChainSpec>) -> &'static RuntimeVersion {
-		&parachain_runtime::VERSION
-	}
+    fn native_runtime_version(_: &Box<dyn ChainSpec>) -> &'static RuntimeVersion {
+        &parachain_runtime::VERSION
+    }
 }
 
 impl SubstrateCli for RelayChainCli {
-	fn impl_name() -> String {
-		"Parachain Collator Template".into()
-	}
+    fn impl_name() -> String {
+        "Parachain Collator Template".into()
+    }
 
-	fn impl_version() -> String {
-		env!("SUBSTRATE_CLI_IMPL_VERSION").into()
-	}
+    fn impl_version() -> String {
+        env!("SUBSTRATE_CLI_IMPL_VERSION").into()
+    }
 
-	fn description() -> String {
-		"Parachain Collator Template\n\nThe command-line arguments provided first will be \
+    fn description() -> String {
+        "Parachain Collator Template\n\nThe command-line arguments provided first will be \
 		passed to the parachain node, while the arguments provided after -- will be passed \
 		to the relaychain node.\n\n\
 		parachain-collator [parachain-args] -- [relaychain-args]"
-			.into()
-	}
+            .into()
+    }
 
-	fn author() -> String {
-		env!("CARGO_PKG_AUTHORS").into()
-	}
+    fn author() -> String {
+        env!("CARGO_PKG_AUTHORS").into()
+    }
 
-	fn support_url() -> String {
-		"https://github.com/paritytech/cumulus/issues/new".into()
-	}
+    fn support_url() -> String {
+        "https://github.com/paritytech/cumulus/issues/new".into()
+    }
 
-	fn copyright_start_year() -> i32 {
-		2017
-	}
+    fn copyright_start_year() -> i32 {
+        2017
+    }
 
-	fn load_spec(&self, id: &str) -> std::result::Result<Box<dyn sc_service::ChainSpec>, String> {
-		polkadot_cli::Cli::from_iter([RelayChainCli::executable_name().to_string()].iter())
-			.load_spec(id)
-	}
+    fn load_spec(&self, id: &str) -> std::result::Result<Box<dyn sc_service::ChainSpec>, String> {
+        polkadot_cli::Cli::from_iter([RelayChainCli::executable_name().to_string()].iter())
+            .load_spec(id)
+    }
 
-	fn native_runtime_version(chain_spec: &Box<dyn ChainSpec>) -> &'static RuntimeVersion {
-		polkadot_cli::Cli::native_runtime_version(chain_spec)
-	}
+    fn native_runtime_version(chain_spec: &Box<dyn ChainSpec>) -> &'static RuntimeVersion {
+        polkadot_cli::Cli::native_runtime_version(chain_spec)
+    }
 }
 
 pub fn generate_genesis_state(chain_spec: &Box<dyn sc_service::ChainSpec>) -> Result<Block> {
-	let storage = chain_spec.build_storage()?;
+    let storage = chain_spec.build_storage()?;
 
-	let child_roots = storage.children_default.iter().map(|(sk, child_content)| {
-		let state_root = <<<Block as BlockT>::Header as HeaderT>::Hashing as HashT>::trie_root(
-			child_content.data.clone().into_iter().collect(),
-		);
-		(sk.clone(), state_root.encode())
-	});
-	let state_root = <<<Block as BlockT>::Header as HeaderT>::Hashing as HashT>::trie_root(
-		storage.top.clone().into_iter().chain(child_roots).collect(),
-	);
+    let child_roots = storage.children_default.iter().map(|(sk, child_content)| {
+        let state_root = <<<Block as BlockT>::Header as HeaderT>::Hashing as HashT>::trie_root(
+            child_content.data.clone().into_iter().collect(),
+        );
+        (sk.clone(), state_root.encode())
+    });
+    let state_root = <<<Block as BlockT>::Header as HeaderT>::Hashing as HashT>::trie_root(
+        storage.top.clone().into_iter().chain(child_roots).collect(),
+    );
 
-	let extrinsics_root =
-		<<<Block as BlockT>::Header as HeaderT>::Hashing as HashT>::trie_root(Vec::new());
+    let extrinsics_root =
+        <<<Block as BlockT>::Header as HeaderT>::Hashing as HashT>::trie_root(Vec::new());
 
-	Ok(Block::new(
-		<<Block as BlockT>::Header as HeaderT>::new(
-			Zero::zero(),
-			extrinsics_root,
-			state_root,
-			Default::default(),
-			Default::default(),
-		),
-		Default::default(),
-	))
+    Ok(Block::new(
+        <<Block as BlockT>::Header as HeaderT>::new(
+            Zero::zero(),
+            extrinsics_root,
+            state_root,
+            Default::default(),
+            Default::default(),
+        ),
+        Default::default(),
+    ))
 }
 
 fn extract_genesis_wasm(chain_spec: &Box<dyn sc_service::ChainSpec>) -> Result<Vec<u8>> {
-	let mut storage = chain_spec.build_storage()?;
+    let mut storage = chain_spec.build_storage()?;
 
-	storage
-		.top
-		.remove(sp_core::storage::well_known_keys::CODE)
-		.ok_or_else(|| "Could not find wasm file in genesis state!".into())
+    storage
+        .top
+        .remove(sp_core::storage::well_known_keys::CODE)
+        .ok_or_else(|| "Could not find wasm file in genesis state!".into())
 }
 
 /// Parse command line arguments into service configuration.
 pub fn run() -> Result<()> {
-	let cli = Cli::from_args();
+    let cli = Cli::from_args();
 
-	match &cli.subcommand {
-		Some(Subcommand::Base(subcommand)) => {
-			let runner = cli.create_runner(subcommand)?;
+    match &cli.subcommand {
+        Some(Subcommand::Base(subcommand)) => {
+            let runner = cli.create_runner(subcommand)?;
 
-			runner.run_subcommand(subcommand, |mut config| {
-				let params = crate::service::new_partial(&mut config)?;
+            runner.run_subcommand(subcommand, |mut config| {
+                let params = crate::service::new_partial(&mut config)?;
 
-				Ok((
-					params.client,
-					params.backend,
-					params.import_queue,
-					params.task_manager,
-				))
-			})
-		}
-		Some(Subcommand::ExportGenesisState(params)) => {
-			sc_cli::init_logger("");
+                Ok((
+                    params.client,
+                    params.backend,
+                    params.import_queue,
+                    params.task_manager,
+                ))
+            })
+        }
+        Some(Subcommand::ExportGenesisState(params)) => {
+            sc_cli::init_logger("");
 
-			let block =
-				generate_genesis_state(&cli.load_spec(&params.chain.clone().unwrap_or_default())?)?;
-			let header_hex = format!("0x{:?}", HexDisplay::from(&block.header().encode()));
+            let block =
+                generate_genesis_state(&cli.load_spec(&params.chain.clone().unwrap_or_default())?)?;
+            let header_hex = format!("0x{:?}", HexDisplay::from(&block.header().encode()));
 
-			if let Some(output) = &params.output {
-				std::fs::write(output, header_hex)?;
-			} else {
-				println!("{}", header_hex);
-			}
+            if let Some(output) = &params.output {
+                std::fs::write(output, header_hex)?;
+            } else {
+                println!("{}", header_hex);
+            }
 
-			Ok(())
-		}
-		Some(Subcommand::ExportGenesisWasm(params)) => {
-			sc_cli::init_logger("");
+            Ok(())
+        }
+        Some(Subcommand::ExportGenesisWasm(params)) => {
+            sc_cli::init_logger("");
 
-			let wasm_file =
-				extract_genesis_wasm(&cli.load_spec(&params.chain.clone().unwrap_or_default())?)?;
+            let wasm_file =
+                extract_genesis_wasm(&cli.load_spec(&params.chain.clone().unwrap_or_default())?)?;
 
-			if let Some(output) = &params.output {
-				std::fs::write(output, wasm_file)?;
-			} else {
-				std::io::stdout().write_all(&wasm_file)?;
-			}
+            if let Some(output) = &params.output {
+                std::fs::write(output, wasm_file)?;
+            } else {
+                std::io::stdout().write_all(&wasm_file)?;
+            }
 
-			Ok(())
-		}
-		None => {
-			let runner = cli.create_runner(&*cli.run)?;
+            Ok(())
+        }
+        None => {
+            let runner = cli.create_runner(&*cli.run)?;
 
-			runner.run_node_until_exit(|config| {
-				// TODO
-				let key = Arc::new(sp_core::Pair::generate().0);
+            runner.run_node_until_exit(|config| {
+                // TODO
+                let key = Arc::new(sp_core::Pair::generate().0);
 
-				let extension = chain_spec::Extensions::try_get(&config.chain_spec);
-				let relay_chain_id = extension.map(|e| e.relay_chain.clone());
-				let para_id = extension.map(|e| e.para_id);
+                let extension = chain_spec::Extensions::try_get(&config.chain_spec);
+                let relay_chain_id = extension.map(|e| e.relay_chain.clone());
+                let para_id = extension.map(|e| e.para_id);
 
-				let polkadot_cli = RelayChainCli::new(
-					config.base_path.as_ref().map(|x| x.path().join("polkadot")),
-					relay_chain_id,
-					[RelayChainCli::executable_name().to_string()]
-						.iter()
-						.chain(cli.relaychain_args.iter()),
-				);
+                let polkadot_cli = RelayChainCli::new(
+                    config.base_path.as_ref().map(|x| x.path().join("polkadot")),
+                    relay_chain_id,
+                    [RelayChainCli::executable_name().to_string()]
+                        .iter()
+                        .chain(cli.relaychain_args.iter()),
+                );
 
-				let id = ParaId::from(cli.run.parachain_id.or(para_id).unwrap_or(200));
+                let id = ParaId::from(cli.run.parachain_id.or(para_id).unwrap_or(200));
 
-				let parachain_account =
-					AccountIdConversion::<polkadot_primitives::v0::AccountId>::into_account(&id);
+                let parachain_account =
+                    AccountIdConversion::<polkadot_primitives::v0::AccountId>::into_account(&id);
 
-				let block =
-					generate_genesis_state(&config.chain_spec).map_err(|e| format!("{:?}", e))?;
-				let genesis_state = format!("0x{:?}", HexDisplay::from(&block.header().encode()));
+                let block =
+                    generate_genesis_state(&config.chain_spec).map_err(|e| format!("{:?}", e))?;
+                let genesis_state = format!("0x{:?}", HexDisplay::from(&block.header().encode()));
 
-				let task_executor = config.task_executor.clone();
-				let polkadot_config =
-					SubstrateCli::create_configuration(&polkadot_cli, &polkadot_cli, task_executor)
-						.map_err(|err| format!("Relay chain argument error: {}", err))?;
+                let task_executor = config.task_executor.clone();
+                let polkadot_config =
+                    SubstrateCli::create_configuration(&polkadot_cli, &polkadot_cli, task_executor)
+                        .map_err(|err| format!("Relay chain argument error: {}", err))?;
 
-				info!("Parachain id: {:?}", id);
-				info!("Parachain Account: {}", parachain_account);
-				info!("Parachain genesis state: {}", genesis_state);
-				info!(
-					"Is collating: {}",
-					if cli.run.base.validator { "yes" } else { "no" }
-				);
+                info!("Parachain id: {:?}", id);
+                info!("Parachain Account: {}", parachain_account);
+                info!("Parachain genesis state: {}", genesis_state);
+                info!(
+                    "Is collating: {}",
+                    if cli.run.base.validator { "yes" } else { "no" }
+                );
 
-				crate::service::run_node(
-					config,
-					key,
-					polkadot_config,
-					id,
-					cli.run.base.validator,
-				)
-				.map(|(x, _)| x)
-			})
-		}
-	}
+                crate::service::run_node(config, key, polkadot_config, id, cli.run.base.validator)
+                    .map(|(x, _)| x)
+            })
+        }
+    }
 }
 
 impl DefaultConfigurationValues for RelayChainCli {
-	fn p2p_listen_port() -> u16 {
-		30334
-	}
+    fn p2p_listen_port() -> u16 {
+        30334
+    }
 
-	fn rpc_ws_listen_port() -> u16 {
-		9945
-	}
+    fn rpc_ws_listen_port() -> u16 {
+        9945
+    }
 
-	fn rpc_http_listen_port() -> u16 {
-		9934
-	}
+    fn rpc_http_listen_port() -> u16 {
+        9934
+    }
 
-	fn prometheus_listen_port() -> u16 {
-		9616
-	}
+    fn prometheus_listen_port() -> u16 {
+        9616
+    }
 }
 
 impl CliConfiguration<Self> for RelayChainCli {
-	fn shared_params(&self) -> &SharedParams {
-		self.base.base.shared_params()
-	}
+    fn shared_params(&self) -> &SharedParams {
+        self.base.base.shared_params()
+    }
 
-	fn import_params(&self) -> Option<&ImportParams> {
-		self.base.base.import_params()
-	}
+    fn import_params(&self) -> Option<&ImportParams> {
+        self.base.base.import_params()
+    }
 
-	fn network_params(&self) -> Option<&NetworkParams> {
-		self.base.base.network_params()
-	}
+    fn network_params(&self) -> Option<&NetworkParams> {
+        self.base.base.network_params()
+    }
 
-	fn keystore_params(&self) -> Option<&KeystoreParams> {
-		self.base.base.keystore_params()
-	}
+    fn keystore_params(&self) -> Option<&KeystoreParams> {
+        self.base.base.keystore_params()
+    }
 
-	fn base_path(&self) -> Result<Option<BasePath>> {
-		Ok(self
-			.shared_params()
-			.base_path()
-			.or_else(|| self.base_path.clone().map(Into::into)))
-	}
+    fn base_path(&self) -> Result<Option<BasePath>> {
+        Ok(self
+            .shared_params()
+            .base_path()
+            .or_else(|| self.base_path.clone().map(Into::into)))
+    }
 
-	fn rpc_http(&self, default_listen_port: u16) -> Result<Option<SocketAddr>> {
-		self.base.base.rpc_http(default_listen_port)
-	}
+    fn rpc_http(&self, default_listen_port: u16) -> Result<Option<SocketAddr>> {
+        self.base.base.rpc_http(default_listen_port)
+    }
 
-	fn rpc_ipc(&self) -> Result<Option<String>> {
-		self.base.base.rpc_ipc()
-	}
+    fn rpc_ipc(&self) -> Result<Option<String>> {
+        self.base.base.rpc_ipc()
+    }
 
-	fn rpc_ws(&self, default_listen_port: u16) -> Result<Option<SocketAddr>> {
-		self.base.base.rpc_ws(default_listen_port)
-	}
+    fn rpc_ws(&self, default_listen_port: u16) -> Result<Option<SocketAddr>> {
+        self.base.base.rpc_ws(default_listen_port)
+    }
 
-	fn prometheus_config(&self, default_listen_port: u16) -> Result<Option<PrometheusConfig>> {
-		self.base.base.prometheus_config(default_listen_port)
-	}
+    fn prometheus_config(&self, default_listen_port: u16) -> Result<Option<PrometheusConfig>> {
+        self.base.base.prometheus_config(default_listen_port)
+    }
 
-	fn init<C: SubstrateCli>(&self) -> Result<()> {
-		unreachable!("PolkadotCli is never initialized; qed");
-	}
+    fn init<C: SubstrateCli>(&self) -> Result<()> {
+        unreachable!("PolkadotCli is never initialized; qed");
+    }
 
-	fn chain_id(&self, is_dev: bool) -> Result<String> {
-		let chain_id = self.base.base.chain_id(is_dev)?;
+    fn chain_id(&self, is_dev: bool) -> Result<String> {
+        let chain_id = self.base.base.chain_id(is_dev)?;
 
-		Ok(if chain_id.is_empty() {
-			self.chain_id.clone().unwrap_or_default()
-		} else {
-			chain_id
-		})
-	}
+        Ok(if chain_id.is_empty() {
+            self.chain_id.clone().unwrap_or_default()
+        } else {
+            chain_id
+        })
+    }
 
-	fn role(&self, is_dev: bool) -> Result<sc_service::Role> {
-		self.base.base.role(is_dev)
-	}
+    fn role(&self, is_dev: bool) -> Result<sc_service::Role> {
+        self.base.base.role(is_dev)
+    }
 
-	fn transaction_pool(&self) -> Result<sc_service::config::TransactionPoolOptions> {
-		self.base.base.transaction_pool()
-	}
+    fn transaction_pool(&self) -> Result<sc_service::config::TransactionPoolOptions> {
+        self.base.base.transaction_pool()
+    }
 
-	fn state_cache_child_ratio(&self) -> Result<Option<usize>> {
-		self.base.base.state_cache_child_ratio()
-	}
+    fn state_cache_child_ratio(&self) -> Result<Option<usize>> {
+        self.base.base.state_cache_child_ratio()
+    }
 
-	fn rpc_methods(&self) -> Result<sc_service::config::RpcMethods> {
-		self.base.base.rpc_methods()
-	}
+    fn rpc_methods(&self) -> Result<sc_service::config::RpcMethods> {
+        self.base.base.rpc_methods()
+    }
 
-	fn rpc_ws_max_connections(&self) -> Result<Option<usize>> {
-		self.base.base.rpc_ws_max_connections()
-	}
+    fn rpc_ws_max_connections(&self) -> Result<Option<usize>> {
+        self.base.base.rpc_ws_max_connections()
+    }
 
-	fn rpc_cors(&self, is_dev: bool) -> Result<Option<Vec<String>>> {
-		self.base.base.rpc_cors(is_dev)
-	}
+    fn rpc_cors(&self, is_dev: bool) -> Result<Option<Vec<String>>> {
+        self.base.base.rpc_cors(is_dev)
+    }
 
-	fn telemetry_external_transport(&self) -> Result<Option<sc_service::config::ExtTransport>> {
-		self.base.base.telemetry_external_transport()
-	}
+    fn telemetry_external_transport(&self) -> Result<Option<sc_service::config::ExtTransport>> {
+        self.base.base.telemetry_external_transport()
+    }
 
-	fn default_heap_pages(&self) -> Result<Option<u64>> {
-		self.base.base.default_heap_pages()
-	}
+    fn default_heap_pages(&self) -> Result<Option<u64>> {
+        self.base.base.default_heap_pages()
+    }
 
-	fn force_authoring(&self) -> Result<bool> {
-		self.base.base.force_authoring()
-	}
+    fn force_authoring(&self) -> Result<bool> {
+        self.base.base.force_authoring()
+    }
 
-	fn disable_grandpa(&self) -> Result<bool> {
-		self.base.base.disable_grandpa()
-	}
+    fn disable_grandpa(&self) -> Result<bool> {
+        self.base.base.disable_grandpa()
+    }
 
-	fn max_runtime_instances(&self) -> Result<Option<usize>> {
-		self.base.base.max_runtime_instances()
-	}
+    fn max_runtime_instances(&self) -> Result<Option<usize>> {
+        self.base.base.max_runtime_instances()
+    }
 
-	fn announce_block(&self) -> Result<bool> {
-		self.base.base.announce_block()
-	}
+    fn announce_block(&self) -> Result<bool> {
+        self.base.base.announce_block()
+    }
 }

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -12,5 +12,5 @@ mod cli;
 mod command;
 
 fn main() -> sc_cli::Result<()> {
-	command::run()
+    command::run()
 }

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -3,7 +3,7 @@
 use ansi_term::Color;
 use cumulus_network::DelayedBlockAnnounceValidator;
 use cumulus_service::{
-	prepare_node_config, start_collator, start_full_node, StartCollatorParams, StartFullNodeParams,
+    prepare_node_config, start_collator, start_full_node, StartCollatorParams, StartFullNodeParams,
 };
 use polkadot_primitives::v0::CollatorPair;
 use sc_executor::native_executor_instance;
@@ -16,9 +16,9 @@ use std::sync::Arc;
 
 // Our native executor instance.
 native_executor_instance!(
-	pub Executor,
-	parachain_runtime::api::dispatch,
-	parachain_runtime::native_version,
+    pub Executor,
+    parachain_runtime::api::dispatch,
+    parachain_runtime::native_version,
 );
 
 /// Starts a `ServiceBuilder` for a full service.
@@ -26,195 +26,195 @@ native_executor_instance!(
 /// Use this macro if you don't actually need the full service, but just the builder in order to
 /// be able to perform chain operations.
 pub fn new_partial(
-	config: &mut Configuration,
+    config: &mut Configuration,
 ) -> Result<
-	PartialComponents<
-		TFullClient<
-			parachain_runtime::opaque::Block,
-			parachain_runtime::RuntimeApi,
-			crate::service::Executor,
-		>,
-		TFullBackend<parachain_runtime::opaque::Block>,
-		(),
-		sp_consensus::import_queue::BasicQueue<
-			parachain_runtime::opaque::Block,
-			PrefixedMemoryDB<BlakeTwo256>,
-		>,
-		sc_transaction_pool::FullPool<
-			parachain_runtime::opaque::Block,
-			TFullClient<
-				parachain_runtime::opaque::Block,
-				parachain_runtime::RuntimeApi,
-				crate::service::Executor,
-			>,
-		>,
-		(),
-	>,
-	sc_service::Error,
+    PartialComponents<
+        TFullClient<
+            parachain_runtime::opaque::Block,
+            parachain_runtime::RuntimeApi,
+            crate::service::Executor,
+        >,
+        TFullBackend<parachain_runtime::opaque::Block>,
+        (),
+        sp_consensus::import_queue::BasicQueue<
+            parachain_runtime::opaque::Block,
+            PrefixedMemoryDB<BlakeTwo256>,
+        >,
+        sc_transaction_pool::FullPool<
+            parachain_runtime::opaque::Block,
+            TFullClient<
+                parachain_runtime::opaque::Block,
+                parachain_runtime::RuntimeApi,
+                crate::service::Executor,
+            >,
+        >,
+        (),
+    >,
+    sc_service::Error,
 > {
-	let inherent_data_providers = sp_inherents::InherentDataProviders::new();
+    let inherent_data_providers = sp_inherents::InherentDataProviders::new();
 
-	let (client, backend, keystore, task_manager) = sc_service::new_full_parts::<
-		parachain_runtime::opaque::Block,
-		parachain_runtime::RuntimeApi,
-		crate::service::Executor,
-	>(&config)?;
-	let client = Arc::new(client);
-	//let select_chain = sc_consensus::LongestChain::new(backend.clone());
+    let (client, backend, keystore, task_manager) = sc_service::new_full_parts::<
+        parachain_runtime::opaque::Block,
+        parachain_runtime::RuntimeApi,
+        crate::service::Executor,
+    >(&config)?;
+    let client = Arc::new(client);
+    //let select_chain = sc_consensus::LongestChain::new(backend.clone());
 
-	let registry = config.prometheus_registry();
+    let registry = config.prometheus_registry();
 
-	let transaction_pool = sc_transaction_pool::BasicPool::new_full(
-		config.transaction_pool.clone(),
-		//std::sync::Arc::new(pool_api),
-		config.prometheus_registry(),
-		task_manager.spawn_handle(),
-		client.clone(),
-	);
+    let transaction_pool = sc_transaction_pool::BasicPool::new_full(
+        config.transaction_pool.clone(),
+        //std::sync::Arc::new(pool_api),
+        config.prometheus_registry(),
+        task_manager.spawn_handle(),
+        client.clone(),
+    );
 
-	let import_queue = cumulus_consensus::import_queue::import_queue(
-		client.clone(),
-		client.clone(),
-		inherent_data_providers.clone(),
-		&task_manager.spawn_handle(),
-		registry.clone(),
-	)?;
+    let import_queue = cumulus_consensus::import_queue::import_queue(
+        client.clone(),
+        client.clone(),
+        inherent_data_providers.clone(),
+        &task_manager.spawn_handle(),
+        registry.clone(),
+    )?;
 
-	let params = PartialComponents {
-		backend,
-		client,
-		import_queue,
-		keystore,
-		task_manager,
-		transaction_pool,
-		inherent_data_providers,
-		select_chain: (),
-		other: (),
-	};
+    let params = PartialComponents {
+        backend,
+        client,
+        import_queue,
+        keystore,
+        task_manager,
+        transaction_pool,
+        inherent_data_providers,
+        select_chain: (),
+        other: (),
+    };
 
-	Ok(params)
+    Ok(params)
 }
 
 /// Run a node with the given parachain `Configuration` and relay chain `Configuration`
 ///
 /// This function blocks until done.
 pub fn run_node(
-	parachain_config: Configuration,
-	collator_key: Arc<CollatorPair>,
-	mut polkadot_config: polkadot_collator::Configuration,
-	id: polkadot_primitives::v0::Id,
-	validator: bool,
+    parachain_config: Configuration,
+    collator_key: Arc<CollatorPair>,
+    mut polkadot_config: polkadot_collator::Configuration,
+    id: polkadot_primitives::v0::Id,
+    validator: bool,
 ) -> sc_service::error::Result<(
-	TaskManager,
-	Arc<
-		TFullClient<
-			parachain_runtime::opaque::Block,
-			parachain_runtime::RuntimeApi,
-			crate::service::Executor,
-		>,
-	>,
+    TaskManager,
+    Arc<
+        TFullClient<
+            parachain_runtime::opaque::Block,
+            parachain_runtime::RuntimeApi,
+            crate::service::Executor,
+        >,
+    >,
 )> {
-	if matches!(parachain_config.role, Role::Light) {
-		return Err("Light client not supported!".into());
-	}
+    if matches!(parachain_config.role, Role::Light) {
+        return Err("Light client not supported!".into());
+    }
 
-	let mut parachain_config = prepare_node_config(parachain_config);
+    let mut parachain_config = prepare_node_config(parachain_config);
 
-	parachain_config.informant_output_format = OutputFormat {
-		enable_color: true,
-		prefix: format!("[{}] ", Color::Yellow.bold().paint("Parachain")),
-	};
-	polkadot_config.informant_output_format = OutputFormat {
-		enable_color: true,
-		prefix: format!("[{}] ", Color::Blue.bold().paint("Relaychain")),
-	};
+    parachain_config.informant_output_format = OutputFormat {
+        enable_color: true,
+        prefix: format!("[{}] ", Color::Yellow.bold().paint("Parachain")),
+    };
+    polkadot_config.informant_output_format = OutputFormat {
+        enable_color: true,
+        prefix: format!("[{}] ", Color::Blue.bold().paint("Relaychain")),
+    };
 
-	let params = new_partial(&mut parachain_config)?;
-	params
-		.inherent_data_providers
-		.register_provider(sp_timestamp::InherentDataProvider)
-		.unwrap();
+    let params = new_partial(&mut parachain_config)?;
+    params
+        .inherent_data_providers
+        .register_provider(sp_timestamp::InherentDataProvider)
+        .unwrap();
 
-	let client = params.client.clone();
-	let backend = params.backend.clone();
-	let block_announce_validator = DelayedBlockAnnounceValidator::new();
-	let block_announce_validator_builder = {
-		let block_announce_validator = block_announce_validator.clone();
-		move |_| Box::new(block_announce_validator) as Box<_>
-	};
+    let client = params.client.clone();
+    let backend = params.backend.clone();
+    let block_announce_validator = DelayedBlockAnnounceValidator::new();
+    let block_announce_validator_builder = {
+        let block_announce_validator = block_announce_validator.clone();
+        move |_| Box::new(block_announce_validator) as Box<_>
+    };
 
-	let prometheus_registry = parachain_config.prometheus_registry().cloned();
-	let transaction_pool = params.transaction_pool.clone();
-	let mut task_manager = params.task_manager;
-	let import_queue = params.import_queue;
-	let (network, network_status_sinks, system_rpc_tx, start_network) =
-		sc_service::build_network(sc_service::BuildNetworkParams {
-				config: &parachain_config,
-				client: client.clone(),
-				transaction_pool: transaction_pool.clone(),
-				spawn_handle: task_manager.spawn_handle(),
-				import_queue,
-				on_demand: None,
-				block_announce_validator_builder: Some(Box::new(block_announce_validator_builder)),
-				finality_proof_request_builder: None,
-				finality_proof_provider: None,
-		})?;
+    let prometheus_registry = parachain_config.prometheus_registry().cloned();
+    let transaction_pool = params.transaction_pool.clone();
+    let mut task_manager = params.task_manager;
+    let import_queue = params.import_queue;
+    let (network, network_status_sinks, system_rpc_tx, start_network) =
+        sc_service::build_network(sc_service::BuildNetworkParams {
+            config: &parachain_config,
+            client: client.clone(),
+            transaction_pool: transaction_pool.clone(),
+            spawn_handle: task_manager.spawn_handle(),
+            import_queue,
+            on_demand: None,
+            block_announce_validator_builder: Some(Box::new(block_announce_validator_builder)),
+            finality_proof_request_builder: None,
+            finality_proof_provider: None,
+        })?;
 
-	sc_service::spawn_tasks(sc_service::SpawnTasksParams {
-		on_demand: None,
-		remote_blockchain: None,
-		rpc_extensions_builder: Box::new(|_| ()),
-		client: client.clone(),
-		transaction_pool: transaction_pool.clone(),
-		task_manager: &mut task_manager,
-		telemetry_connection_sinks: Default::default(),
-		config: parachain_config,
-		keystore: params.keystore,
-		backend,
-		network: network.clone(),
-		network_status_sinks,
-		system_rpc_tx,
-	})?;
+    sc_service::spawn_tasks(sc_service::SpawnTasksParams {
+        on_demand: None,
+        remote_blockchain: None,
+        rpc_extensions_builder: Box::new(|_| ()),
+        client: client.clone(),
+        transaction_pool: transaction_pool.clone(),
+        task_manager: &mut task_manager,
+        telemetry_connection_sinks: Default::default(),
+        config: parachain_config,
+        keystore: params.keystore,
+        backend,
+        network: network.clone(),
+        network_status_sinks,
+        system_rpc_tx,
+    })?;
 
-	let announce_block = Arc::new(move |hash, data| network.announce_block(hash, data));
+    let announce_block = Arc::new(move |hash, data| network.announce_block(hash, data));
 
-	if validator {
-		let proposer_factory = sc_basic_authorship::ProposerFactory::new(
-			client.clone(),
-			transaction_pool,
-			prometheus_registry.as_ref(),
-		);
+    if validator {
+        let proposer_factory = sc_basic_authorship::ProposerFactory::new(
+            client.clone(),
+            transaction_pool,
+            prometheus_registry.as_ref(),
+        );
 
-		let params = StartCollatorParams {
-			para_id: id,
-			block_import: client.clone(),
-			proposer_factory,
-			inherent_data_providers: params.inherent_data_providers,
-			block_status: client.clone(),
-			announce_block,
-			client: client.clone(),
-			block_announce_validator,
-			task_manager: &mut task_manager,
-			polkadot_config,
-			collator_key,
-		};
+        let params = StartCollatorParams {
+            para_id: id,
+            block_import: client.clone(),
+            proposer_factory,
+            inherent_data_providers: params.inherent_data_providers,
+            block_status: client.clone(),
+            announce_block,
+            client: client.clone(),
+            block_announce_validator,
+            task_manager: &mut task_manager,
+            polkadot_config,
+            collator_key,
+        };
 
-		start_collator(params)?;
-	} else {
-		let params = StartFullNodeParams {
-			client: client.clone(),
-			announce_block,
-			polkadot_config,
-			collator_key,
-			block_announce_validator,
-			task_manager: &mut task_manager,
-			para_id: id,
-		};
+        start_collator(params)?;
+    } else {
+        let params = StartFullNodeParams {
+            client: client.clone(),
+            announce_block,
+            polkadot_config,
+            collator_key,
+            block_announce_validator,
+            task_manager: &mut task_manager,
+            para_id: id,
+        };
 
-		start_full_node(params)?;
-	}
+        start_full_node(params)?;
+    }
 
-	start_network.start_network();
+    start_network.start_network();
 
-	Ok((task_manager, client))
+    Ok((task_manager, client))
 }

--- a/pallets/dex-pallet/Cargo.toml
+++ b/pallets/dex-pallet/Cargo.toml
@@ -37,13 +37,18 @@ default-features = false
 git = 'https://github.com/paritytech/substrate.git'
 branch = "rococo-branch"
 
-[dependencies.generic-asset]
+[dependencies.balances]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-package = 'pallet-generic-asset'
+package = 'pallet-balances'
 branch = "rococo-branch"
 
 [dependencies.sp-runtime]
+default-features = false
+git = 'https://github.com/paritytech/substrate.git'
+branch = "rococo-branch"
+
+[dependencies.sp-arithmetic]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
 branch = "rococo-branch"
@@ -63,9 +68,10 @@ default = ['std']
 std = [
     'serde',
     'codec/std',
-    'generic-asset/std',
+    'balances/std',
     'frame-support/std',
     'frame-system/std',
     'sp-std/std',
     'sp-runtime/std',
+    'sp-arithmetic/std'
 ]

--- a/pallets/dex-pallet/src/exchange.rs
+++ b/pallets/dex-pallet/src/exchange.rs
@@ -1,0 +1,185 @@
+use super::*;
+
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[derive(Encode, Decode, Clone, PartialEq, Eq, Debug)]
+pub struct Exchange<T: Trait> {
+    first_currency_pool: BalanceOf<T>,
+    second_currency_pool: BalanceOf<T>,
+    pub invariant: BalanceOf<T>,
+    total_shares: BalanceOf<T>,
+    shares: BTreeMap<T::AccountId, BalanceOf<T>>,
+}
+
+impl<T: Trait> Default for Exchange<T> {
+    fn default() -> Self {
+        Self {
+            first_currency_pool: BalanceOf::<T>::default(),
+            second_currency_pool: BalanceOf::<T>::default(),
+            invariant: BalanceOf::<T>::default(),
+            total_shares: BalanceOf::<T>::default(),
+            shares: BTreeMap::new(),
+        }
+    }
+}
+
+impl<T: Trait> Exchange<T> {
+    pub fn initialize_new(
+        first_currency_amount: BalanceOf<T>,
+        second_currency_amount: BalanceOf<T>,
+        sender: T::AccountId,
+    ) -> Self {
+        let mut shares_map = BTreeMap::new();
+        shares_map.insert(sender, T::InitialShares::get());
+        Self {
+            first_currency_pool: first_currency_amount,
+            second_currency_pool: second_currency_amount,
+            invariant: first_currency_amount * second_currency_amount,
+            total_shares: T::InitialShares::get(),
+            shares: shares_map,
+        }
+    }
+
+    pub fn calculate_ksm_to_token_swap(
+        &self,
+        first_currency_amount: BalanceOf<T>,
+    ) -> (BalanceOf<T>, BalanceOf<T>, BalanceOf<T>) {
+        let fee = first_currency_amount * T::ExchangeFeeRateNominator::get()
+            / T::ExchangeFeeRateDenominator::get();
+        let new_ksm_pool = self.first_currency_pool + first_currency_amount;
+        let temp_ksm_pool = new_ksm_pool - fee;
+        let new_token_pool = self.invariant / temp_ksm_pool;
+        let second_currency_amount = self.second_currency_pool - new_token_pool;
+        (new_ksm_pool, new_token_pool, second_currency_amount)
+    }
+
+    pub fn calculate_token_to_ksm_swap(
+        &self,
+        second_currency_amount: BalanceOf<T>,
+    ) -> (BalanceOf<T>, BalanceOf<T>, BalanceOf<T>) {
+        let fee = second_currency_amount * T::ExchangeFeeRateNominator::get()
+            / T::ExchangeFeeRateDenominator::get();
+        let new_token_pool = self.second_currency_pool + second_currency_amount;
+        let temp_token_pool = new_token_pool - fee;
+        let new_ksm_pool = self.invariant / temp_token_pool;
+        let first_currency_amount = self.first_currency_pool - new_ksm_pool;
+        (new_ksm_pool, new_token_pool, first_currency_amount)
+    }
+
+    pub fn calculate_costs(&self, shares: BalanceOf<T>) -> (BalanceOf<T>, BalanceOf<T>) {
+        let first_currency_cost = self.first_currency_pool * shares / self.total_shares;
+        let second_currency_cost = self.second_currency_pool * shares / self.total_shares;
+
+        (first_currency_cost, second_currency_cost)
+    }
+
+    pub fn invest(
+        &mut self,
+        first_currency_amount: BalanceOf<T>,
+        second_currency_amount: BalanceOf<T>,
+        shares: BalanceOf<T>,
+        sender: &T::AccountId,
+    ) {
+        let updated_shares = if let Some(prev_shares) = self.shares.get(sender) {
+            *prev_shares + shares
+        } else {
+            shares
+        };
+        self.shares.insert(sender.clone(), updated_shares);
+        self.total_shares += shares;
+        self.first_currency_pool += first_currency_amount;
+        self.second_currency_pool += second_currency_amount;
+        self.invariant = self.first_currency_pool * self.second_currency_pool;
+    }
+
+    pub fn divest(
+        &mut self,
+        first_currency_amount: BalanceOf<T>,
+        second_currency_amount: BalanceOf<T>,
+        shares: BalanceOf<T>,
+        sender: &T::AccountId,
+    ) {
+        if let Some(share) = self.shares.get_mut(sender) {
+            *share -= shares;
+        }
+
+        self.total_shares -= shares;
+        self.first_currency_pool -= first_currency_amount;
+        self.second_currency_pool -= second_currency_amount;
+        if self.total_shares == BalanceOf::<T>::zero() {
+            self.invariant = BalanceOf::<T>::zero();
+        } else {
+            self.invariant = self.first_currency_pool * self.second_currency_pool;
+        }
+    }
+
+    pub fn update_pools(
+        &mut self,
+        first_currency_pool: BalanceOf<T>,
+        second_currency_pool: BalanceOf<T>,
+    ) {
+        self.first_currency_pool = first_currency_pool;
+        self.second_currency_pool = second_currency_pool;
+        self.invariant = self.first_currency_pool * self.second_currency_pool;
+    }
+
+    pub fn ensure_launch(&self) -> dispatch::DispatchResult {
+        ensure!(
+            self.invariant == BalanceOf::<T>::zero(),
+            Error::<T>::InvariantNotNull
+        );
+        ensure!(
+            self.total_shares == BalanceOf::<T>::zero(),
+            Error::<T>::TotalSharesNotNull
+        );
+        Ok(())
+    }
+
+    pub fn ensure_token_amount(
+        &self,
+        token_out_amount: BalanceOf<T>,
+        min_token_out_amount: BalanceOf<T>,
+    ) -> dispatch::DispatchResult {
+        ensure!(
+            token_out_amount >= min_token_out_amount,
+            Error::<T>::TokenAmountBelowExpectation
+        );
+        ensure!(
+            token_out_amount <= self.second_currency_pool,
+            Error::<T>::InsufficientPool
+        );
+        Ok(())
+    }
+
+    pub fn ensure_burned_shares(
+        &self,
+        sender: &T::AccountId,
+        shares_burned: BalanceOf<T>,
+    ) -> dispatch::DispatchResult {
+        ensure!(
+            shares_burned > BalanceOf::<T>::zero(),
+            Error::<T>::InvalidShares
+        );
+        if let Some(shares) = self.shares.get(sender) {
+            ensure!(*shares >= shares_burned, Error::<T>::InsufficientShares);
+            Ok(())
+        } else {
+            Err(Error::<T>::DoesNotOwnShare.into())
+        }
+    }
+
+    pub fn ensure_ksm_amount(
+        &self,
+        ksm_out_amount: BalanceOf<T>,
+        min_ksm_out_amount: BalanceOf<T>,
+    ) -> dispatch::DispatchResult {
+        ensure!(
+            ksm_out_amount >= min_ksm_out_amount,
+            Error::<T>::KsmAmountBelowExpectation
+        );
+        ensure!(
+            ksm_out_amount <= self.first_currency_pool,
+            Error::<T>::InsufficientPool
+        );
+        Ok(())
+    }
+}

--- a/pallets/dex-pallet/src/exchange.rs
+++ b/pallets/dex-pallet/src/exchange.rs
@@ -149,7 +149,7 @@ impl<T: Trait> Exchange<T> {
     ) -> dispatch::DispatchResult {
         ensure!(
             asset_out_amount >= min_asset_out_amount,
-            Error::<T>::AssetAmountBelowExpectation
+            Error::<T>::SecondAssetAmountBelowExpectation
         );
         ensure!(
             asset_out_amount <= self.second_asset_pool,
@@ -182,7 +182,7 @@ impl<T: Trait> Exchange<T> {
     ) -> dispatch::DispatchResult {
         ensure!(
             first_asset_out_amount >= min_first_asset_out_amount,
-            Error::<T>::AssetAmountBelowExpectation
+            Error::<T>::SecondAssetAmountBelowExpectation
         );
         ensure!(
             first_asset_out_amount <= self.first_asset_pool,

--- a/pallets/dex-pallet/src/exchange.rs
+++ b/pallets/dex-pallet/src/exchange.rs
@@ -3,8 +3,8 @@ use super::*;
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(Encode, Decode, Clone, PartialEq, Eq, Debug)]
 pub struct Exchange<T: Trait> {
-    first_currency_pool: BalanceOf<T>,
-    second_currency_pool: BalanceOf<T>,
+    first_asset_pool: BalanceOf<T>,
+    second_asset_pool: BalanceOf<T>,
     pub invariant: BalanceOf<T>,
     total_shares: BalanceOf<T>,
     shares: BTreeMap<T::AccountId, BalanceOf<T>>,
@@ -13,8 +13,8 @@ pub struct Exchange<T: Trait> {
 impl<T: Trait> Default for Exchange<T> {
     fn default() -> Self {
         Self {
-            first_currency_pool: BalanceOf::<T>::default(),
-            second_currency_pool: BalanceOf::<T>::default(),
+            first_asset_pool: BalanceOf::<T>::default(),
+            second_asset_pool: BalanceOf::<T>::default(),
             invariant: BalanceOf::<T>::default(),
             total_shares: BalanceOf::<T>::default(),
             shares: BTreeMap::new(),
@@ -24,58 +24,66 @@ impl<T: Trait> Default for Exchange<T> {
 
 impl<T: Trait> Exchange<T> {
     pub fn initialize_new(
-        first_currency_amount: BalanceOf<T>,
-        second_currency_amount: BalanceOf<T>,
+        first_asset_amount: BalanceOf<T>,
+        second_asset_amount: BalanceOf<T>,
         sender: T::AccountId,
     ) -> Self {
         let mut shares_map = BTreeMap::new();
         shares_map.insert(sender, T::InitialShares::get());
         Self {
-            first_currency_pool: first_currency_amount,
-            second_currency_pool: second_currency_amount,
-            invariant: first_currency_amount * second_currency_amount,
+            first_asset_pool: first_asset_amount,
+            second_asset_pool: second_asset_amount,
+            invariant: first_asset_amount * second_asset_amount,
             total_shares: T::InitialShares::get(),
             shares: shares_map,
         }
     }
 
-    pub fn calculate_ksm_to_token_swap(
+    pub fn calculate_first_to_second_asset_swap(
         &self,
-        first_currency_amount: BalanceOf<T>,
+        first_asset_amount: BalanceOf<T>,
     ) -> (BalanceOf<T>, BalanceOf<T>, BalanceOf<T>) {
-        let fee = first_currency_amount * T::ExchangeFeeRateNominator::get()
+        let fee = first_asset_amount * T::ExchangeFeeRateNominator::get()
             / T::ExchangeFeeRateDenominator::get();
-        let new_ksm_pool = self.first_currency_pool + first_currency_amount;
-        let temp_ksm_pool = new_ksm_pool - fee;
-        let new_token_pool = self.invariant / temp_ksm_pool;
-        let second_currency_amount = self.second_currency_pool - new_token_pool;
-        (new_ksm_pool, new_token_pool, second_currency_amount)
+        let new_first_asset_pool = self.first_asset_pool + first_asset_amount;
+        let temp_first_asset_pool = new_first_asset_pool - fee;
+        let new_second_asset_pool = self.invariant / temp_first_asset_pool;
+        let second_asset_amount = self.second_asset_pool - new_second_asset_pool;
+        (
+            new_first_asset_pool,
+            new_second_asset_pool,
+            second_asset_amount,
+        )
     }
 
-    pub fn calculate_token_to_ksm_swap(
+    pub fn calculate_second_to_first_asset_swap(
         &self,
-        second_currency_amount: BalanceOf<T>,
+        second_asset_amount: BalanceOf<T>,
     ) -> (BalanceOf<T>, BalanceOf<T>, BalanceOf<T>) {
-        let fee = second_currency_amount * T::ExchangeFeeRateNominator::get()
+        let fee = second_asset_amount * T::ExchangeFeeRateNominator::get()
             / T::ExchangeFeeRateDenominator::get();
-        let new_token_pool = self.second_currency_pool + second_currency_amount;
-        let temp_token_pool = new_token_pool - fee;
-        let new_ksm_pool = self.invariant / temp_token_pool;
-        let first_currency_amount = self.first_currency_pool - new_ksm_pool;
-        (new_ksm_pool, new_token_pool, first_currency_amount)
+        let new_second_asset_pool = self.second_asset_pool + second_asset_amount;
+        let temp_second_asset_pool = new_second_asset_pool - fee;
+        let new_first_asset_pool = self.invariant / temp_second_asset_pool;
+        let first_asset_amount = self.first_asset_pool - new_first_asset_pool;
+        (
+            new_first_asset_pool,
+            new_second_asset_pool,
+            first_asset_amount,
+        )
     }
 
     pub fn calculate_costs(&self, shares: BalanceOf<T>) -> (BalanceOf<T>, BalanceOf<T>) {
-        let first_currency_cost = self.first_currency_pool * shares / self.total_shares;
-        let second_currency_cost = self.second_currency_pool * shares / self.total_shares;
+        let first_asset_cost = self.first_asset_pool * shares / self.total_shares;
+        let second_asset_cost = self.second_asset_pool * shares / self.total_shares;
 
-        (first_currency_cost, second_currency_cost)
+        (first_asset_cost, second_asset_cost)
     }
 
     pub fn invest(
         &mut self,
-        first_currency_amount: BalanceOf<T>,
-        second_currency_amount: BalanceOf<T>,
+        first_asset_amount: BalanceOf<T>,
+        second_asset_amount: BalanceOf<T>,
         shares: BalanceOf<T>,
         sender: &T::AccountId,
     ) {
@@ -86,15 +94,15 @@ impl<T: Trait> Exchange<T> {
         };
         self.shares.insert(sender.clone(), updated_shares);
         self.total_shares += shares;
-        self.first_currency_pool += first_currency_amount;
-        self.second_currency_pool += second_currency_amount;
-        self.invariant = self.first_currency_pool * self.second_currency_pool;
+        self.first_asset_pool += first_asset_amount;
+        self.second_asset_pool += second_asset_amount;
+        self.invariant = self.first_asset_pool * self.second_asset_pool;
     }
 
     pub fn divest(
         &mut self,
-        first_currency_amount: BalanceOf<T>,
-        second_currency_amount: BalanceOf<T>,
+        first_asset_amount: BalanceOf<T>,
+        second_asset_amount: BalanceOf<T>,
         shares: BalanceOf<T>,
         sender: &T::AccountId,
     ) {
@@ -103,23 +111,23 @@ impl<T: Trait> Exchange<T> {
         }
 
         self.total_shares -= shares;
-        self.first_currency_pool -= first_currency_amount;
-        self.second_currency_pool -= second_currency_amount;
+        self.first_asset_pool -= first_asset_amount;
+        self.second_asset_pool -= second_asset_amount;
         if self.total_shares == BalanceOf::<T>::zero() {
             self.invariant = BalanceOf::<T>::zero();
         } else {
-            self.invariant = self.first_currency_pool * self.second_currency_pool;
+            self.invariant = self.first_asset_pool * self.second_asset_pool;
         }
     }
 
     pub fn update_pools(
         &mut self,
-        first_currency_pool: BalanceOf<T>,
-        second_currency_pool: BalanceOf<T>,
+        first_asset_pool: BalanceOf<T>,
+        second_asset_pool: BalanceOf<T>,
     ) {
-        self.first_currency_pool = first_currency_pool;
-        self.second_currency_pool = second_currency_pool;
-        self.invariant = self.first_currency_pool * self.second_currency_pool;
+        self.first_asset_pool = first_asset_pool;
+        self.second_asset_pool = second_asset_pool;
+        self.invariant = self.first_asset_pool * self.second_asset_pool;
     }
 
     pub fn ensure_launch(&self) -> dispatch::DispatchResult {
@@ -134,17 +142,17 @@ impl<T: Trait> Exchange<T> {
         Ok(())
     }
 
-    pub fn ensure_token_amount(
+    pub fn ensure_second_asset_amount(
         &self,
-        token_out_amount: BalanceOf<T>,
-        min_token_out_amount: BalanceOf<T>,
+        asset_out_amount: BalanceOf<T>,
+        min_asset_out_amount: BalanceOf<T>,
     ) -> dispatch::DispatchResult {
         ensure!(
-            token_out_amount >= min_token_out_amount,
-            Error::<T>::TokenAmountBelowExpectation
+            asset_out_amount >= min_asset_out_amount,
+            Error::<T>::AssetAmountBelowExpectation
         );
         ensure!(
-            token_out_amount <= self.second_currency_pool,
+            asset_out_amount <= self.second_asset_pool,
             Error::<T>::InsufficientPool
         );
         Ok(())
@@ -167,17 +175,17 @@ impl<T: Trait> Exchange<T> {
         }
     }
 
-    pub fn ensure_ksm_amount(
+    pub fn ensure_first_asset_amount(
         &self,
-        ksm_out_amount: BalanceOf<T>,
-        min_ksm_out_amount: BalanceOf<T>,
+        first_asset_out_amount: BalanceOf<T>,
+        min_first_asset_out_amount: BalanceOf<T>,
     ) -> dispatch::DispatchResult {
         ensure!(
-            ksm_out_amount >= min_ksm_out_amount,
-            Error::<T>::KsmAmountBelowExpectation
+            first_asset_out_amount >= min_first_asset_out_amount,
+            Error::<T>::AssetAmountBelowExpectation
         );
         ensure!(
-            ksm_out_amount <= self.first_currency_pool,
+            first_asset_out_amount <= self.first_asset_pool,
             Error::<T>::InsufficientPool
         );
         Ok(())

--- a/pallets/dex-pallet/src/lib.rs
+++ b/pallets/dex-pallet/src/lib.rs
@@ -99,8 +99,8 @@ decl_error! {
         TotalSharesNotNull,
         LowKsmAmount,
         LowassetAmount,
-        KsmAmountBelowExpectation,
-        AssetAmountBelowExpectation,
+        FirstAssetAmountBelowExpectation,
+        SecondAssetAmountBelowExpectation,
         InsufficientPool,
         InvalidShares,
         InsufficientShares,
@@ -530,11 +530,11 @@ impl<T: Trait> Module<T> {
     ) -> dispatch::DispatchResult {
         ensure!(
             first_asset_cost >= min_first_asset_received,
-            Error::<T>::KsmAmountBelowExpectation
+            Error::<T>::FirstAssetAmountBelowExpectation
         );
         ensure!(
             second_asset_cost >= min_second_asset_received,
-            Error::<T>::AssetAmountBelowExpectation
+            Error::<T>::SecondAssetAmountBelowExpectation
         );
         Ok(())
     }

--- a/pallets/dex-pallet/src/mock.rs
+++ b/pallets/dex-pallet/src/mock.rs
@@ -5,13 +5,13 @@ use frame_support::{impl_outer_origin, parameter_types, weights::Weight};
 use frame_system as system;
 use sp_core::H256;
 use sp_runtime::{
-	testing::Header,
-	traits::{BlakeTwo256, IdentityLookup},
-	Perbill,
+    testing::Header,
+    traits::{BlakeTwo256, IdentityLookup},
+    Perbill,
 };
 
 impl_outer_origin! {
-	pub enum Origin for Test {}
+    pub enum Origin for Test {}
 }
 
 // For testing the pallet, we construct most of a mock runtime. This means
@@ -20,47 +20,47 @@ impl_outer_origin! {
 #[derive(Clone, Eq, PartialEq)]
 pub struct Test;
 parameter_types! {
-	pub const BlockHashCount: u64 = 250;
-	pub const MaximumBlockWeight: Weight = 1024;
-	pub const MaximumBlockLength: u32 = 2 * 1024;
-	pub const AvailableBlockRatio: Perbill = Perbill::from_percent(75);
+    pub const BlockHashCount: u64 = 250;
+    pub const MaximumBlockWeight: Weight = 1024;
+    pub const MaximumBlockLength: u32 = 2 * 1024;
+    pub const AvailableBlockRatio: Perbill = Perbill::from_percent(75);
 }
 impl system::Trait for Test {
-	type BaseCallFilter = ();
-	type Origin = Origin;
-	type Call = ();
-	type Index = u64;
-	type BlockNumber = u64;
-	type Hash = H256;
-	type Hashing = BlakeTwo256;
-	type AccountId = u64;
-	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
-	type Event = ();
-	type BlockHashCount = BlockHashCount;
-	type MaximumBlockWeight = MaximumBlockWeight;
-	type DbWeight = ();
-	type BlockExecutionWeight = ();
-	type ExtrinsicBaseWeight = ();
-	type MaximumExtrinsicWeight = MaximumBlockWeight;
-	type MaximumBlockLength = MaximumBlockLength;
-	type AvailableBlockRatio = AvailableBlockRatio;
-	type Version = ();
-	type ModuleToIndex = ();
-	type AccountData = ();
-	type OnNewAccount = ();
-	type OnKilledAccount = ();
+    type BaseCallFilter = ();
+    type Origin = Origin;
+    type Call = ();
+    type Index = u64;
+    type BlockNumber = u64;
+    type Hash = H256;
+    type Hashing = BlakeTwo256;
+    type AccountId = u64;
+    type Lookup = IdentityLookup<Self::AccountId>;
+    type Header = Header;
+    type Event = ();
+    type BlockHashCount = BlockHashCount;
+    type MaximumBlockWeight = MaximumBlockWeight;
+    type DbWeight = ();
+    type BlockExecutionWeight = ();
+    type ExtrinsicBaseWeight = ();
+    type MaximumExtrinsicWeight = MaximumBlockWeight;
+    type MaximumBlockLength = MaximumBlockLength;
+    type AvailableBlockRatio = AvailableBlockRatio;
+    type Version = ();
+    type ModuleToIndex = ();
+    type AccountData = ();
+    type OnNewAccount = ();
+    type OnKilledAccount = ();
 }
 impl Trait for Test {
-	type Event = ();
+    type Event = ();
 }
 pub type TemplateModule = Module<Test>;
 
 // This function basically just builds a genesis storage key/value store according to
 // our desired mockup.
 pub fn new_test_ext() -> sp_io::TestExternalities {
-	system::GenesisConfig::default()
-		.build_storage::<Test>()
-		.unwrap()
-		.into()
+    system::GenesisConfig::default()
+        .build_storage::<Test>()
+        .unwrap()
+        .into()
 }

--- a/pallets/dex-xcmp/src/lib.rs
+++ b/pallets/dex-xcmp/src/lib.rs
@@ -182,8 +182,7 @@ impl<T: Trait> DownwardMessageHandler for Module<T> {
                 // TODO figure out a better way to ensure relay chain asset was not created
 
                 if !<CurrencyByParaId<T>>::contains_key(ParaId::default()) {
-                    let dex_asset_options =
-                        Self::create_default_dex_asset_options();
+                    let dex_asset_options = Self::create_default_dex_asset_options();
 
                     <generic_asset::Module<T>>::create_asset(
                         Some(relay_chain_currency_id),

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -31,7 +31,7 @@ pallet-randomness-collective-flip = { git = "https://github.com/paritytech/subst
 pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "rococo-branch" }
 pallet-sudo = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "rococo-branch" }
 pallet-transaction-payment = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "rococo-branch" }
-generic-asset = { git = "https://github.com/paritytech/substrate", package = "pallet-generic-asset", default-features = false, branch = "rococo-branch"  }
+pallet-balances = { git = "https://github.com/paritytech/substrate", package = "pallet-balances", default-features = false, branch = "rococo-branch"  }
 
 # Cumulus dependencies
 cumulus-runtime = { git = "https://github.com/paritytech/cumulus",  default-features = false, rev = '96da14c14fb785e106bb89a18c9dedaf2f789d2c' }
@@ -62,7 +62,7 @@ std = [
 	"frame-support/std",
 	"frame-executive/std",
 	"frame-system/std",
-	"generic-asset/std",
+	"pallet-balances/std",
 	"pallet-randomness-collective-flip/std",
 	"pallet-timestamp/std",
 	"pallet-sudo/std",

--- a/runtime/build.rs
+++ b/runtime/build.rs
@@ -17,10 +17,10 @@
 use wasm_builder_runner::WasmBuilder;
 
 fn main() {
-	WasmBuilder::new()
-		.with_current_project()
-		.with_wasm_builder_from_crates("1.0.11")
-		.export_heap_base()
-		.import_memory()
-		.build()
+    WasmBuilder::new()
+        .with_current_project()
+        .with_wasm_builder_from_crates("1.0.11")
+        .export_heap_base()
+        .import_memory()
+        .build()
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -47,7 +47,6 @@ pub use frame_support::{
 };
 
 pub use dex_pallet::Call as DexPalletCall;
-pub use generic_asset::Call as GenericAssetCall;
 pub use pallet_balances::Call as BalancesCall;
 pub use pallet_timestamp::Call as TimestampCall;
 #[cfg(any(feature = "std", test))]
@@ -216,11 +215,11 @@ parameter_types! {
 }
 
 impl pallet_transaction_payment::Trait for Runtime {
-    type Currency = generic_asset::SpendingAssetCurrency<Runtime>;
-    type OnTransactionPayment = ();
-    type TransactionByteFee = TransactionByteFee;
-    type WeightToFee = IdentityFee<Balance>;
-    type FeeMultiplierUpdate = ();
+	type Currency = Balances;
+	type OnTransactionPayment = ();
+	type TransactionByteFee = TransactionByteFee;
+	type WeightToFee = IdentityFee<Balance>;
+	type FeeMultiplierUpdate = ();
 }
 
 impl pallet_balances::Trait for Runtime {
@@ -276,9 +275,10 @@ parameter_types! {
 
 impl dex_pallet::Trait for Runtime {
     type Event = Event;
+    type Currency = Balances;
+    type InitialShares = InitialShares;
     type AssetId = AssetId;
     type KSMAssetId = KSMAssetId;
-    type InitialShares = InitialShares;
     type ExchangeFeeRateNominator = ExchangeFeeRateNominator;
     type ExchangeFeeRateDenominator = ExchangeFeeRateDenominator;
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -27,10 +27,10 @@ use dex_xcmp::XCMPMessage;
 use sp_api::impl_runtime_apis;
 use sp_core::OpaqueMetadata;
 use sp_runtime::{
-	create_runtime_str, generic, impl_opaque_keys,
-	traits::{BlakeTwo256, Block as BlockT, IdentifyAccount, IdentityLookup, Saturating, Verify},
-	transaction_validity::{TransactionSource, TransactionValidity},
-	ApplyExtrinsicResult, MultiSignature,
+    create_runtime_str, generic, impl_opaque_keys,
+    traits::{BlakeTwo256, Block as BlockT, IdentifyAccount, IdentityLookup, Saturating, Verify},
+    transaction_validity::{TransactionSource, TransactionValidity},
+    ApplyExtrinsicResult, MultiSignature,
 };
 use sp_std::prelude::*;
 #[cfg(feature = "std")]
@@ -40,14 +40,15 @@ use sp_version::RuntimeVersion;
 // A few exports that help ease life for downstream crates.
 
 pub use frame_support::{
-	construct_runtime, parameter_types,
-	traits::{Get, KeyOwnerProofSystem, Randomness},
-	weights::{constants::WEIGHT_PER_SECOND, IdentityFee, Weight},
-	StorageValue,
+    construct_runtime, parameter_types,
+    traits::{Get, KeyOwnerProofSystem, Randomness},
+    weights::{constants::WEIGHT_PER_SECOND, IdentityFee, Weight},
+    StorageValue,
 };
 
 pub use dex_pallet::Call as DexPalletCall;
 pub use generic_asset::Call as GenericAssetCall;
+pub use pallet_balances::Call as BalancesCall;
 pub use pallet_timestamp::Call as TimestampCall;
 #[cfg(any(feature = "std", test))]
 pub use sp_runtime::BuildStorage;
@@ -70,7 +71,7 @@ pub type AccountIndex = u32;
 /// Balance of an account.
 pub type Balance = u128;
 
-/// Asset id for custom assets
+/// Asset id for different assets
 pub type AssetId = u64;
 
 /// Index of a transaction in the chain.
@@ -87,33 +88,33 @@ pub type DigestItem = generic::DigestItem<Hash>;
 /// of data like extrinsics, allowing for them to continue syncing the network through upgrades
 /// to even the core datastructures.
 pub mod opaque {
-	use super::*;
+    use super::*;
 
-	pub use sp_runtime::OpaqueExtrinsic as UncheckedExtrinsic;
+    pub use sp_runtime::OpaqueExtrinsic as UncheckedExtrinsic;
 
-	/// Opaque block header type.
-	pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
-	/// Opaque block type.
-	pub type Block = generic::Block<Header, UncheckedExtrinsic>;
-	/// Opaque block identifier type.
-	pub type BlockId = generic::BlockId<Block>;
+    /// Opaque block header type.
+    pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
+    /// Opaque block type.
+    pub type Block = generic::Block<Header, UncheckedExtrinsic>;
+    /// Opaque block identifier type.
+    pub type BlockId = generic::BlockId<Block>;
 
-	pub type SessionHandlers = ();
+    pub type SessionHandlers = ();
 
-	impl_opaque_keys! {
-		pub struct SessionKeys {}
-	}
+    impl_opaque_keys! {
+        pub struct SessionKeys {}
+    }
 }
 
 /// This runtime version.
 pub const VERSION: RuntimeVersion = RuntimeVersion {
-	spec_name: create_runtime_str!("wasm-test-parachain"),
-	impl_name: create_runtime_str!("wasm-test-parachain"),
-	authoring_version: 3,
-	spec_version: 4,
-	impl_version: 4,
-	apis: RUNTIME_API_VERSIONS,
-	transaction_version: 1,
+    spec_name: create_runtime_str!("wasm-test-parachain"),
+    impl_name: create_runtime_str!("wasm-test-parachain"),
+    authoring_version: 3,
+    spec_version: 4,
+    impl_version: 4,
+    apis: RUNTIME_API_VERSIONS,
+    transaction_version: 1,
 };
 
 pub const MILLISECS_PER_BLOCK: u64 = 3000;
@@ -133,166 +134,172 @@ pub const PRIMARY_PROBABILITY: (u64, u64) = (1, 4);
 /// The version infromation used to identify this runtime when compiled natively.
 #[cfg(feature = "std")]
 pub fn native_version() -> NativeVersion {
-	NativeVersion {
-		runtime_version: VERSION,
-		can_author_with: Default::default(),
-	}
+    NativeVersion {
+        runtime_version: VERSION,
+        can_author_with: Default::default(),
+    }
 }
 
 parameter_types! {
-	pub const BlockHashCount: BlockNumber = 250;
-	pub const MaximumBlockWeight: Weight = 2 * WEIGHT_PER_SECOND;
-	/// Assume 10% of weight for average on_initialize calls.
-	pub MaximumExtrinsicWeight: Weight = AvailableBlockRatio::get()
-		.saturating_sub(Perbill::from_percent(10)) * MaximumBlockWeight::get();
-	pub const AvailableBlockRatio: Perbill = Perbill::from_percent(75);
-	pub const MaximumBlockLength: u32 = 5 * 1024 * 1024;
-	pub const Version: RuntimeVersion = VERSION;
-	pub const ExtrinsicBaseWeight: Weight = 10_000_000;
+    pub const BlockHashCount: BlockNumber = 250;
+    pub const MaximumBlockWeight: Weight = 2 * WEIGHT_PER_SECOND;
+    /// Assume 10% of weight for average on_initialize calls.
+    pub MaximumExtrinsicWeight: Weight = AvailableBlockRatio::get()
+        .saturating_sub(Perbill::from_percent(10)) * MaximumBlockWeight::get();
+    pub const AvailableBlockRatio: Perbill = Perbill::from_percent(75);
+    pub const MaximumBlockLength: u32 = 5 * 1024 * 1024;
+    pub const Version: RuntimeVersion = VERSION;
+    pub const ExtrinsicBaseWeight: Weight = 10_000_000;
 }
 
 impl frame_system::Trait for Runtime {
-	/// The identifier used to distinguish between accounts.
-	type AccountId = AccountId;
-	/// The aggregated dispatch type that is available for extrinsics.
-	type Call = Call;
-	/// The lookup mechanism to get account ID from whatever is passed in dispatchers.
-	type Lookup = IdentityLookup<AccountId>;
-	/// The index type for storing how many extrinsics an account has signed.
-	type Index = Index;
-	/// The index type for blocks.
-	type BlockNumber = BlockNumber;
-	/// The type for hashing blocks and tries.
-	type Hash = Hash;
-	/// The hashing algorithm used.
-	type Hashing = BlakeTwo256;
-	/// The header type.
-	type Header = generic::Header<BlockNumber, BlakeTwo256>;
-	/// The ubiquitous event type.
-	type Event = Event;
-	/// The ubiquitous origin type.
-	type Origin = Origin;
-	/// Maximum number of block number to block hash mappings to keep (oldest pruned first).
-	type BlockHashCount = BlockHashCount;
-	/// Maximum weight of each block. With a default weight system of 1byte == 1weight, 4mb is ok.
-	type MaximumBlockWeight = MaximumBlockWeight;
-	/// Maximum size of all encoded transactions (in bytes) that are allowed in one block.
-	type MaximumBlockLength = MaximumBlockLength;
-	/// Portion of the block weight that is available to all normal transactions.
-	type AvailableBlockRatio = AvailableBlockRatio;
-	/// Runtime version.
-	type Version = Version;
-	/// Converts a module to an index of this module in the runtime.
-	type ModuleToIndex = ModuleToIndex;
-	type AccountData = ();
-	type OnNewAccount = ();
-	type OnKilledAccount = ();
-	type DbWeight = ();
-	type ExtrinsicBaseWeight = ExtrinsicBaseWeight;
-	type BlockExecutionWeight = ();
-	type MaximumExtrinsicWeight = MaximumExtrinsicWeight;
-	type BaseCallFilter = ();
-	type SystemWeightInfo = ();
+    /// The identifier used to distinguish between accounts.
+    type AccountId = AccountId;
+    /// The aggregated dispatch type that is available for extrinsics.
+    type Call = Call;
+    /// The lookup mechanism to get account ID from whatever is passed in dispatchers.
+    type Lookup = IdentityLookup<AccountId>;
+    /// The index type for storing how many extrinsics an account has signed.
+    type Index = Index;
+    /// The index type for blocks.
+    type BlockNumber = BlockNumber;
+    /// The type for hashing blocks and tries.
+    type Hash = Hash;
+    /// The hashing algorithm used.
+    type Hashing = BlakeTwo256;
+    /// The header type.
+    type Header = generic::Header<BlockNumber, BlakeTwo256>;
+    /// The ubiquitous event type.
+    type Event = Event;
+    /// The ubiquitous origin type.
+    type Origin = Origin;
+    /// Maximum number of block number to block hash mappings to keep (oldest pruned first).
+    type BlockHashCount = BlockHashCount;
+    /// Maximum weight of each block. With a default weight system of 1byte == 1weight, 4mb is ok.
+    type MaximumBlockWeight = MaximumBlockWeight;
+    /// Maximum size of all encoded transactions (in bytes) that are allowed in one block.
+    type MaximumBlockLength = MaximumBlockLength;
+    /// Portion of the block weight that is available to all normal transactions.
+    type AvailableBlockRatio = AvailableBlockRatio;
+    /// Runtime version.
+    type Version = Version;
+    /// Converts a module to an index of this module in the runtime.
+    type ModuleToIndex = ModuleToIndex;
+    type AccountData = pallet_balances::AccountData<Balance>;
+    type OnNewAccount = ();
+    type OnKilledAccount = ();
+    type DbWeight = ();
+    type ExtrinsicBaseWeight = ExtrinsicBaseWeight;
+    type BlockExecutionWeight = ();
+    type MaximumExtrinsicWeight = MaximumExtrinsicWeight;
+    type BaseCallFilter = ();
+    type SystemWeightInfo = ();
 }
 
 parameter_types! {
-	pub const MinimumPeriod: u64 = SLOT_DURATION / 2;
+    pub const MinimumPeriod: u64 = SLOT_DURATION / 2;
 }
 
 impl pallet_timestamp::Trait for Runtime {
-	/// A timestamp: milliseconds since the unix epoch.
-	type Moment = u64;
-	type OnTimestampSet = ();
-	type MinimumPeriod = MinimumPeriod;
-	type WeightInfo = ();
+    /// A timestamp: milliseconds since the unix epoch.
+    type Moment = u64;
+    type OnTimestampSet = ();
+    type MinimumPeriod = MinimumPeriod;
+    type WeightInfo = ();
 }
 
 parameter_types! {
-	pub const ExistentialDeposit: u128 = 500;
-	pub const TransferFee: u128 = 0;
-	pub const CreationFee: u128 = 0;
-	pub const TransactionByteFee: u128 = 1;
+    pub const ExistentialDeposit: u128 = 500;
+    pub const TransferFee: u128 = 0;
+    pub const CreationFee: u128 = 0;
+    pub const TransactionByteFee: u128 = 1;
 }
 
 impl pallet_transaction_payment::Trait for Runtime {
-	type Currency = generic_asset::SpendingAssetCurrency<Runtime>;
-	type OnTransactionPayment = ();
-	type TransactionByteFee = TransactionByteFee;
-	type WeightToFee = IdentityFee<Balance>;
-	type FeeMultiplierUpdate = ();
+    type Currency = generic_asset::SpendingAssetCurrency<Runtime>;
+    type OnTransactionPayment = ();
+    type TransactionByteFee = TransactionByteFee;
+    type WeightToFee = IdentityFee<Balance>;
+    type FeeMultiplierUpdate = ();
+}
+
+impl pallet_balances::Trait for Runtime {
+    /// The type for recording an account's balance.
+    type Balance = Balance;
+    /// The ubiquitous event type.
+    type Event = Event;
+    type DustRemoval = ();
+    type ExistentialDeposit = ExistentialDeposit;
+    type AccountStore = System;
+    type WeightInfo = ();
 }
 
 impl pallet_sudo::Trait for Runtime {
-	type Call = Call;
-	type Event = Event;
+    type Call = Call;
+    type Event = Event;
 }
 
 impl cumulus_parachain_upgrade::Trait for Runtime {
-	type Event = Event;
-	type OnValidationFunctionParams = ();
+    type Event = Event;
+    type OnValidationFunctionParams = ();
 }
 
 parameter_types! {
-	pub storage ParachainId: cumulus_primitives::ParaId = 200.into();
+    pub storage ParachainId: cumulus_primitives::ParaId = 200.into();
 }
 
 impl cumulus_message_broker::Trait for Runtime {
-	type Event = Event;
-	type DownwardMessageHandlers = DexXCMP;
-	type UpwardMessage = cumulus_upward_message::WestendUpwardMessage;
-	type ParachainId = ParachainId;
-	type XCMPMessage = XCMPMessage<AccountId, Balance>;
-	type XCMPMessageHandlers = DexXCMP;
+    type Event = Event;
+    type DownwardMessageHandlers = DexXCMP;
+    type UpwardMessage = cumulus_upward_message::WestendUpwardMessage;
+    type ParachainId = ParachainId;
+    type XCMPMessage = XCMPMessage<AccountId, Balance>;
+    type XCMPMessageHandlers = DexXCMP;
 }
 
 impl dex_xcmp::Trait for Runtime {
-	type Event = Event;
-	type UpwardMessageSender = MessageBroker;
-	type UpwardMessage = cumulus_upward_message::WestendUpwardMessage;
-	// type Currency = generic_asset::SpendingAssetCurrency<Runtime>;
-	type XCMPMessageSender = MessageBroker;
-}
-
-impl generic_asset::Trait for Runtime {
-	type Event = Event;
-	type Balance = Balance;
-	type AssetId = AssetId;
+    type Event = Event;
+    type UpwardMessageSender = MessageBroker;
+    type UpwardMessage = cumulus_upward_message::WestendUpwardMessage;
+    type XCMPMessageSender = MessageBroker;
 }
 
 parameter_types! {
-	// Main currency id
-	pub const KSMAssetId: AssetId = 1;
-	pub const InitialShares: Balance = 1000;
+    // Main currency id
+    pub const KSMAssetId: AssetId = 0;
+    pub const InitialShares: Balance = 1000;
 
-	// 3/1000
-	pub const ExchangeFeeRateNominator: Balance = 3;
-	pub const ExchangeFeeRateDenominator: Balance = 1000;
+    // 3/1000
+    pub const ExchangeFeeRateNominator: Balance = 3;
+    pub const ExchangeFeeRateDenominator: Balance = 1000;
 }
 
 impl dex_pallet::Trait for Runtime {
-	type Event = Event;
-	type InitialShares = InitialShares;
-	type ExchangeFeeRateNominator = ExchangeFeeRateNominator;
-	type ExchangeFeeRateDenominator = ExchangeFeeRateDenominator;
+    type Event = Event;
+    type AssetId = AssetId;
+    type KSMAssetId = KSMAssetId;
+    type InitialShares = InitialShares;
+    type ExchangeFeeRateNominator = ExchangeFeeRateNominator;
+    type ExchangeFeeRateDenominator = ExchangeFeeRateDenominator;
 }
 
 construct_runtime! {
-	pub enum Runtime where
-		Block = Block,
-		NodeBlock = opaque::Block,
-		UncheckedExtrinsic = UncheckedExtrinsic
-	{
-		System: frame_system::{Module, Call, Storage, Config, Event<T>},
-		Timestamp: pallet_timestamp::{Module, Call, Storage, Inherent},
-		Sudo: pallet_sudo::{Module, Call, Storage, Config<T>, Event<T>},
-		RandomnessCollectiveFlip: pallet_randomness_collective_flip::{Module, Call, Storage},
-		ParachainUpgrade: cumulus_parachain_upgrade::{Module, Call, Storage, Inherent, Event},
-		MessageBroker: cumulus_message_broker::{Module, Call, Inherent, Event<T>},
-		DexXCMP: dex_xcmp::{Module, Call, Event<T>, Config<T>},
-		TransactionPayment: pallet_transaction_payment::{Module, Storage},
-		GenericAsset: generic_asset::{Module, Call, Config<T>, Storage, Event<T>},
-		DexPallet: dex_pallet::{Module, Config<T>, Call, Storage, Event<T>},
-	}
+    pub enum Runtime where
+        Block = Block,
+        NodeBlock = opaque::Block,
+        UncheckedExtrinsic = UncheckedExtrinsic
+    {
+        System: frame_system::{Module, Call, Storage, Config, Event<T>},
+        Timestamp: pallet_timestamp::{Module, Call, Storage, Inherent},
+        Sudo: pallet_sudo::{Module, Call, Storage, Config<T>, Event<T>},
+        RandomnessCollectiveFlip: pallet_randomness_collective_flip::{Module, Call, Storage},
+        ParachainUpgrade: cumulus_parachain_upgrade::{Module, Call, Storage, Inherent, Event},
+        MessageBroker: cumulus_message_broker::{Module, Call, Inherent, Event<T>},
+        DexXCMP: dex_xcmp::{Module, Call, Event<T>, Config<T>},
+        TransactionPayment: pallet_transaction_payment::{Module, Storage},
+        Balances: pallet_balances::{Module, Call, Storage, Config<T>, Event<T>},
+        DexPallet: dex_pallet::{Module, Config<T>, Call, Storage, Event<T>},
+    }
 }
 
 /// The address format for describing accounts.
@@ -307,12 +314,12 @@ pub type SignedBlock = generic::SignedBlock<Block>;
 pub type BlockId = generic::BlockId<Block>;
 /// The SignedExtension to the basic transaction logic.
 pub type SignedExtra = (
-	frame_system::CheckSpecVersion<Runtime>,
-	frame_system::CheckGenesis<Runtime>,
-	frame_system::CheckEra<Runtime>,
-	frame_system::CheckNonce<Runtime>,
-	frame_system::CheckWeight<Runtime>,
-	pallet_transaction_payment::ChargeTransactionPayment<Runtime>,
+    frame_system::CheckSpecVersion<Runtime>,
+    frame_system::CheckGenesis<Runtime>,
+    frame_system::CheckEra<Runtime>,
+    frame_system::CheckNonce<Runtime>,
+    frame_system::CheckWeight<Runtime>,
+    pallet_transaction_payment::ChargeTransactionPayment<Runtime>,
 );
 /// Unchecked extrinsic type as expected by this runtime.
 pub type UncheckedExtrinsic = generic::UncheckedExtrinsic<Address, Call, Signature, SignedExtra>;
@@ -320,84 +327,84 @@ pub type UncheckedExtrinsic = generic::UncheckedExtrinsic<Address, Call, Signatu
 pub type CheckedExtrinsic = generic::CheckedExtrinsic<AccountId, Call, SignedExtra>;
 /// Executive: handles dispatch to the various modules.
 pub type Executive = frame_executive::Executive<
-	Runtime,
-	Block,
-	frame_system::ChainContext<Runtime>,
-	Runtime,
-	AllModules,
+    Runtime,
+    Block,
+    frame_system::ChainContext<Runtime>,
+    Runtime,
+    AllModules,
 >;
 
 impl_runtime_apis! {
-	impl sp_api::Core<Block> for Runtime {
-		fn version() -> RuntimeVersion {
-			VERSION
-		}
+    impl sp_api::Core<Block> for Runtime {
+        fn version() -> RuntimeVersion {
+            VERSION
+        }
 
-		fn execute_block(block: Block) {
-			Executive::execute_block(block)
-		}
+        fn execute_block(block: Block) {
+            Executive::execute_block(block)
+        }
 
-		fn initialize_block(header: &<Block as BlockT>::Header) {
-			Executive::initialize_block(header)
-		}
-	}
+        fn initialize_block(header: &<Block as BlockT>::Header) {
+            Executive::initialize_block(header)
+        }
+    }
 
-	impl sp_api::Metadata<Block> for Runtime {
-		fn metadata() -> OpaqueMetadata {
-			Runtime::metadata().into()
-		}
-	}
+    impl sp_api::Metadata<Block> for Runtime {
+        fn metadata() -> OpaqueMetadata {
+            Runtime::metadata().into()
+        }
+    }
 
-	impl sp_block_builder::BlockBuilder<Block> for Runtime {
-		fn apply_extrinsic(
-			extrinsic: <Block as BlockT>::Extrinsic,
-		) -> ApplyExtrinsicResult {
-			Executive::apply_extrinsic(extrinsic)
-		}
+    impl sp_block_builder::BlockBuilder<Block> for Runtime {
+        fn apply_extrinsic(
+            extrinsic: <Block as BlockT>::Extrinsic,
+        ) -> ApplyExtrinsicResult {
+            Executive::apply_extrinsic(extrinsic)
+        }
 
-		fn finalize_block() -> <Block as BlockT>::Header {
-			Executive::finalize_block()
-		}
+        fn finalize_block() -> <Block as BlockT>::Header {
+            Executive::finalize_block()
+        }
 
-		fn inherent_extrinsics(data: sp_inherents::InherentData) -> Vec<<Block as BlockT>::Extrinsic> {
-			data.create_extrinsics()
-		}
+        fn inherent_extrinsics(data: sp_inherents::InherentData) -> Vec<<Block as BlockT>::Extrinsic> {
+            data.create_extrinsics()
+        }
 
-		fn check_inherents(block: Block, data: sp_inherents::InherentData) -> sp_inherents::CheckInherentsResult {
-			data.check_extrinsics(&block)
-		}
+        fn check_inherents(block: Block, data: sp_inherents::InherentData) -> sp_inherents::CheckInherentsResult {
+            data.check_extrinsics(&block)
+        }
 
-		fn random_seed() -> <Block as BlockT>::Hash {
-			RandomnessCollectiveFlip::random_seed()
-		}
-	}
+        fn random_seed() -> <Block as BlockT>::Hash {
+            RandomnessCollectiveFlip::random_seed()
+        }
+    }
 
-	impl sp_transaction_pool::runtime_api::TaggedTransactionQueue<Block> for Runtime {
-		fn validate_transaction(
-			source: TransactionSource,
-			tx: <Block as BlockT>::Extrinsic,
-		) -> TransactionValidity {
-			Executive::validate_transaction(source, tx)
-		}
-	}
+    impl sp_transaction_pool::runtime_api::TaggedTransactionQueue<Block> for Runtime {
+        fn validate_transaction(
+            source: TransactionSource,
+            tx: <Block as BlockT>::Extrinsic,
+        ) -> TransactionValidity {
+            Executive::validate_transaction(source, tx)
+        }
+    }
 
-	impl sp_offchain::OffchainWorkerApi<Block> for Runtime {
-		fn offchain_worker(header: &<Block as BlockT>::Header) {
-			Executive::offchain_worker(header)
-		}
-	}
+    impl sp_offchain::OffchainWorkerApi<Block> for Runtime {
+        fn offchain_worker(header: &<Block as BlockT>::Header) {
+            Executive::offchain_worker(header)
+        }
+    }
 
-	impl sp_session::SessionKeys<Block> for Runtime {
-		fn decode_session_keys(
-			encoded: Vec<u8>,
-		) -> Option<Vec<(Vec<u8>, sp_core::crypto::KeyTypeId)>> {
-			opaque::SessionKeys::decode_into_raw_public_keys(&encoded)
-		}
+    impl sp_session::SessionKeys<Block> for Runtime {
+        fn decode_session_keys(
+            encoded: Vec<u8>,
+        ) -> Option<Vec<(Vec<u8>, sp_core::crypto::KeyTypeId)>> {
+            opaque::SessionKeys::decode_into_raw_public_keys(&encoded)
+        }
 
-		fn generate_session_keys(seed: Option<Vec<u8>>) -> Vec<u8> {
-			opaque::SessionKeys::generate(seed)
-		}
-	}
+        fn generate_session_keys(seed: Option<Vec<u8>>) -> Vec<u8> {
+            opaque::SessionKeys::generate(seed)
+        }
+    }
 }
 
 cumulus_runtime::register_validate_block!(Block, Executive);


### PR DESCRIPTION
1. Direct token pools implemented.

 - For asset -> asset pool runtime representation i chose `double_map`, identified by both asset ids. Don't sure if it's a good approach, as then we need to constantly apply some rule to ensure correct order. Thought about hashing or some arithmetic operations performed for both identificators, though couldn`t figure out appropriate algorithm.   
1. `generic-assets` dependency replaced in favor of `Currency` trait on `dex_parachain` side, which makes implementation much more flexible. (`dex_xcmp` reworking still work in progress)
1. `AssetBalances` runtime storage introduced for the purpose of tracking other parachain assets. ( which are not supported on dex parachain natively)
1. Introduced treasury account for further fee charge.
1. Overflow risks are partially resolved. (Still need to rework exchange related methods).

Closes: https://github.com/subdarkdex/subdex-chain/issues/2
Partially implements https://github.com/subdarkdex/subdex-chain/issues/9