### PR TITLE
Dex_xcmp: get rid of generic_asset, new downward/xcmp message handlers draft implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1192,12 +1192,13 @@ version = "2.0.0-rc5"
 dependencies = [
  "cumulus-primitives",
  "cumulus-upward-message",
+ "dex-pallet",
  "frame-support",
  "frame-system",
- "pallet-generic-asset",
  "parity-scale-codec",
  "polkadot-parachain",
  "serde",
+ "sp-arithmetic",
 ]
 
 [[package]]
@@ -3766,18 +3767,6 @@ dependencies = [
  "serde",
  "sp-finality-tracker",
  "sp-inherents",
- "sp-runtime",
- "sp-std",
-]
-
-[[package]]
-name = "pallet-generic-asset"
-version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#83544d41abcc0e3d3cbbd6aa510e04dc50863e5c"
-dependencies = [
- "frame-support",
- "frame-system",
- "parity-scale-codec",
  "sp-runtime",
  "sp-std",
 ]

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -2,7 +2,7 @@
 
 use cumulus_primitives::ParaId;
 use parachain_runtime::{
-    AccountId, DexPalletConfig, BalancesConfig, DexXCMPConfig, GenesisConfig, KSMAssetId,
+    AccountId, BalancesConfig, DexPalletConfig, DexXCMPConfig, GenesisConfig,
     Signature, SudoConfig, SystemConfig, WASM_BINARY,
 };
 use sc_chain_spec::{ChainSpecExtension, ChainSpecGroup};

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -2,8 +2,8 @@
 
 use cumulus_primitives::ParaId;
 use parachain_runtime::{
-    AccountId, BalancesConfig, DexPalletConfig, DexXCMPConfig, GenesisConfig,
-    Signature, SudoConfig, SystemConfig, WASM_BINARY,
+    AccountId, BalancesConfig, DexPalletConfig, DexXCMPConfig, GenesisConfig, Signature,
+    SudoConfig, SystemConfig, WASM_BINARY,
 };
 use sc_chain_spec::{ChainSpecExtension, ChainSpecGroup};
 use sc_service::ChainType;

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -2,7 +2,7 @@
 
 use cumulus_primitives::ParaId;
 use parachain_runtime::{
-    AccountId, DexPalletConfig, DexXCMPConfig, GenericAssetConfig, GenesisConfig, KSMAssetId,
+    AccountId, DexPalletConfig, BalancesConfig, DexXCMPConfig, GenesisConfig, KSMAssetId,
     Signature, SudoConfig, SystemConfig, WASM_BINARY,
 };
 use sc_chain_spec::{ChainSpecExtension, ChainSpecGroup};
@@ -120,11 +120,12 @@ fn testnet_genesis(
         pallet_sudo: Some(SudoConfig {
             key: root_key.clone(),
         }),
-        dex_xcmp: Some(DexXCMPConfig {
-            dex_account_id: root_key.clone(),
-        }),
         dex_pallet: Some(DexPalletConfig {
             dex_account_id: root_key,
+        }),
+        dex_xcmp: Some(DexXCMPConfig {
+            // 0 id reserved for main currency
+            next_asset_id: 1,
         }),
         pallet_balances: Some(BalancesConfig {
             balances: endowed_accounts

--- a/pallets/dex-xcmp/Cargo.toml
+++ b/pallets/dex-xcmp/Cargo.toml
@@ -38,12 +38,6 @@ default-features = false
 git = 'https://github.com/paritytech/substrate.git'
 branch = "rococo-branch"
 
-[dependencies.generic-asset]
-git = 'https://github.com/paritytech/substrate.git'
-package = "pallet-generic-asset"
-default-features = false
-branch = "rococo-branch"
-
 [dependencies.polkadot-parachain]
 git = "https://github.com/paritytech/polkadot"
 branch = "rococo-branch"
@@ -54,6 +48,14 @@ features = ['derive']
 optional = true
 version = '1.0.101'
 
+[dependencies.sp-arithmetic]
+default-features = false
+git = 'https://github.com/paritytech/substrate.git'
+branch = "rococo-branch"
+
+[dependencies.dex-pallet]
+path = '../dex-pallet'
+default-features = false
 
 [features]
 default = ['std']

--- a/pallets/dex-xcmp/src/lib.rs
+++ b/pallets/dex-xcmp/src/lib.rs
@@ -309,7 +309,10 @@ impl<T: Trait> XCMPMessageHandler<XCMPMessage<T::AccountId, BalanceOf<T>, AssetI
 }
 
 impl<T: Trait> Module<T> {
-    pub fn ensure_asset_id_exists(para_id: ParaId, para_asset_id: AssetIdOf<T>) -> Result<AssetIdOf<T>, Error<T>>  {
+    pub fn ensure_asset_id_exists(
+        para_id: ParaId,
+        para_asset_id: AssetIdOf<T>,
+    ) -> Result<AssetIdOf<T>, Error<T>> {
         ensure!(
             <AssetIdByParaAssetId<T>>::contains_key(para_id, para_asset_id),
             Error::<T>::AssetIdDoesNotExist

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -215,11 +215,11 @@ parameter_types! {
 }
 
 impl pallet_transaction_payment::Trait for Runtime {
-	type Currency = Balances;
-	type OnTransactionPayment = ();
-	type TransactionByteFee = TransactionByteFee;
-	type WeightToFee = IdentityFee<Balance>;
-	type FeeMultiplierUpdate = ();
+    type Currency = Balances;
+    type OnTransactionPayment = ();
+    type TransactionByteFee = TransactionByteFee;
+    type WeightToFee = IdentityFee<Balance>;
+    type FeeMultiplierUpdate = ();
 }
 
 impl pallet_balances::Trait for Runtime {
@@ -252,7 +252,7 @@ impl cumulus_message_broker::Trait for Runtime {
     type DownwardMessageHandlers = DexXCMP;
     type UpwardMessage = cumulus_upward_message::WestendUpwardMessage;
     type ParachainId = ParachainId;
-    type XCMPMessage = XCMPMessage<AccountId, Balance>;
+    type XCMPMessage = XCMPMessage<AccountId, Balance, AssetId>;
     type XCMPMessageHandlers = DexXCMP;
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -22,7 +22,6 @@
 #[cfg(feature = "std")]
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
-use dex_pallet;
 use dex_xcmp::XCMPMessage;
 use sp_api::impl_runtime_apis;
 use sp_core::OpaqueMetadata;


### PR DESCRIPTION
The scope of this PR includes:

1. Downward/xcmp message handlers implementation, working  both with native currency and custom token assets transfer messages.
1. Extrinsics for transferring  both natively supported currency and custom tokens from `dex_parachain`.